### PR TITLE
allow xmlrpc media upload requests to work too ...

### DIFF
--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -30,6 +30,10 @@ class Tiny_Settings extends Tiny_WP_Base {
     public function __construct() {
         parent::__construct();
         $this->notices = new Tiny_Notices();
+
+        if(defined('XMLRPC_REQUEST') && XMLRPC_REQUEST && $this->get_api_key()) {
+            $this->compressor = Tiny_Compress::get_compressor($this->get_api_key(), $this->get_method('after_compress_callback'));
+        }
     }
 
     public function admin_init() {


### PR DESCRIPTION
Currently the plugin doesn't work for XMLRPC file upload requests - this is a quick and dirty hack that seems to work (at least for me).

You seemingly can't just call Tiny_Settings::admin_init() as the Wordpress XMLRPC stuff  doesn't seem to support/setup the various current_user_can() and similar functions. 

Using Zend Framework (1.12)'s XmlRpc client the following code now seems to work:
```php
$xmlrpc = new Zend_XmlRpc_Client('http://www.example.com/xmlrpc.php');
$wp = $xmlrpc->getProxy('wp');
$image = array(
    'name' => 'something.jpg', 
    'type' => 'image/jpg',
    'bits' => new Zend_XmlRpc_Value_Base64(file_get_contents('image.jpg'), false),
     'overwrite' => false );

$attachment_info = $wp->uploadFile(1, 'admin', 'secret_password', $image);
var_dump($attachment_info);

```

