### PR TITLE
add checks for metadata keys

### DIFF
--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -42,7 +42,7 @@ class Tiny_Image {
 		if ( ! is_array( $this->wp_metadata ) ) {
 			$this->wp_metadata = wp_get_attachment_metadata( $this->id );
 		}
-		if ( ! is_array( $this->wp_metadata ) ) {
+		if ( ! is_array( $this->wp_metadata ) || ! isset($this->wp_metadata['file'] ) ) {
 			return;
 		}
 		$path_info = pathinfo( $this->wp_metadata['file'] );
@@ -68,6 +68,7 @@ class Tiny_Image {
 		$filenames = array();
 
 		if ( is_array( $this->wp_metadata )
+			&& isset( $this->wp_metadata['file'] ) 
 			&& isset( $this->wp_metadata['sizes'] )
 			&& is_array( $this->wp_metadata['sizes'] ) ) {
 


### PR DESCRIPTION
Adding a bit of double checking to avoid undefined index errors for unique attachment cases.

Re: https://github.com/tinify/wordpress-plugin/issues/12