### PR TITLE
mb_strimwidth is not supported

### DIFF
--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -1,0 +1,39 @@
+<?php
+/*
+* Tiny Compress Images - WordPress plugin.
+* Copyright (C) 2015-2018 Tinify B.V.
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc., 51
+* Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+class Tiny_Helpers
+{
+    /**
+     * truncate_text will truncate a string to a given length.
+     * When text is longer than the given length, the string will be truncated and
+     * the last characters will be replaced with an ellipsis.
+     *
+     * @param string $text the text
+     * @param integer $length the maximum length of the string
+     * @return string the truncated string
+     */
+    public static function truncate_text(string $text, int $length)
+    {
+        if (mb_strlen($text) > $length) {
+            return mb_substr($text, 0, $length) . '...';
+        }
+        return $text;
+    }
+}

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -24,6 +24,9 @@ class Tiny_Helpers {
 	 * truncate_text will truncate a string to a given length.
 	 * When text is longer than the given length, the string will be truncated and
 	 * the last characters will be replaced with an ellipsis.
+	 * 
+	 * We can use mb_strlen & mb_substr as WordPress provides a compat function for 
+	 * it if mbstring php module is not installed.
 	 *
 	 * @param string $text the text
 	 * @param integer $length the maximum length of the string

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -31,7 +31,7 @@ class Tiny_Helpers {
 	 */
 	public static function truncate_text( string $text, int $length ) {
 		if ( mb_strlen( $text ) > $length ) {
-			return mb_substr( $text, 0, $length ) . '...';
+			return mb_substr( $text, 0, $length - 3 ) . '...';
 		}
 		return $text;
 	}

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -18,22 +18,21 @@
 * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-class Tiny_Helpers
-{
-    /**
-     * truncate_text will truncate a string to a given length.
-     * When text is longer than the given length, the string will be truncated and
-     * the last characters will be replaced with an ellipsis.
-     *
-     * @param string $text the text
-     * @param integer $length the maximum length of the string
-     * @return string the truncated string
-     */
-    public static function truncate_text(string $text, int $length)
-    {
-        if (mb_strlen($text) > $length) {
-            return mb_substr($text, 0, $length) . '...';
-        }
-        return $text;
-    }
+class Tiny_Helpers {
+
+	/**
+	 * truncate_text will truncate a string to a given length.
+	 * When text is longer than the given length, the string will be truncated and
+	 * the last characters will be replaced with an ellipsis.
+	 *
+	 * @param string $text the text
+	 * @param integer $length the maximum length of the string
+	 * @return string the truncated string
+	 */
+	public static function truncate_text( string $text, int $length ) {
+		if ( mb_strlen( $text ) > $length ) {
+			return mb_substr( $text, 0, $length ) . '...';
+		}
+		return $text;
+	}
 }

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -385,7 +385,7 @@ class Tiny_Image {
 				if ( isset( $size->meta['error'] ) && isset( $size->meta['message'] ) ) {
 					if ( null === $last_timestamp || $last_timestamp < $size->meta['timestamp'] ) {
 						$last_timestamp = $size->meta['timestamp'];
-						$error_message = mb_strimwidth( $size->meta['message'], 0 , 140, '...' );
+						$error_message = Tiny_Helpers::truncate_text($size->meta['message'], 140);
 					}
 				}
 			}

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -164,7 +164,7 @@ class Tiny_Image {
 	}
 
 	public function file_type_allowed() {
-		return in_array( $this->get_mime_type(), array( 'image/jpeg', 'image/png', 'image/webp') );
+		return in_array( $this->get_mime_type(), array( 'image/jpeg', 'image/png', 'image/webp' ) );
 	}
 
 	public function get_mime_type() {
@@ -385,7 +385,7 @@ class Tiny_Image {
 				if ( isset( $size->meta['error'] ) && isset( $size->meta['message'] ) ) {
 					if ( null === $last_timestamp || $last_timestamp < $size->meta['timestamp'] ) {
 						$last_timestamp = $size->meta['timestamp'];
-						$error_message = Tiny_Helpers::truncate_text($size->meta['message'], 140);
+						$error_message = Tiny_Helpers::truncate_text( $size->meta['message'], 140 );
 					}
 				}
 			}

--- a/test/unit/TinyHelpersTest.php
+++ b/test/unit/TinyHelpersTest.php
@@ -12,7 +12,7 @@ class Tiny_Helpers_Test extends Tiny_TestCase
     public function test_truncates_text_to_length()
     {
         $input_text = "Text to be truncated because it is long";
-        $expected_output = "Text to be truncated...";
+        $expected_output = "Text to be trunca...";
 
         $this->assertEquals($expected_output, Tiny_Helpers::truncate_text($input_text, 20));
     }

--- a/test/unit/TinyHelpersTest.php
+++ b/test/unit/TinyHelpersTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once dirname(__FILE__) . '/TinyTestCase.php';
+
+class Tiny_Helpers_Test extends Tiny_TestCase
+{
+    public function set_up()
+    {
+        parent::set_up();
+    }
+
+    public function test_truncates_text_to_length()
+    {
+        $input_text = "Text to be truncated because it is long";
+        $expected_output = "Text to be truncated...";
+
+        $this->assertEquals($expected_output, Tiny_Helpers::truncate_text($input_text, 20));
+    }
+
+    public function test_will_not_truncate_if_text_is_shorter_than_length()
+    {
+        $input_text = "Text will not be truncated";
+
+        $this->assertEquals($input_text, Tiny_Helpers::truncate_text($input_text, 26));
+    }
+}


### PR DESCRIPTION
The user is provided a truncated error message if an image failed to compress. When the host does not have the php module [mbstring](https://www.php.net/manual/en/book.mbstring.php) installed this will result in an exception causing the plug-in to stop working:

<img width="812" alt="Screenshot 2025-01-14 at 22 02 40" src="https://github.com/user-attachments/assets/e8f220ce-7d0d-4012-85c8-f00cfeda0939" />

To still be able to process multibyte strings we will use the compatibility function provided by WordPress to truncate the error message:
https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/compat.php#L180

Once we can support `wp_html_excerpt` in our test suite, we should use that as it provides similar functionality.
