### PR TITLE
3.4.6 Missing import

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://tinypng.com/
 Tags: compress images, compression, image size, page speed, performance
 Requires at least: 3.4
 Tested up to: 6.7
-Stable tag: 3.4.5
+Stable tag: 3.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,9 @@ A: Yes! After installing the plugin, go to *Media > Bulk Optimization*, and clic
 A: You can upgrade to a paid account by adding your *Payment details* on your [account dashboard](https://tinypng.com/dashboard/api). Additional compressions above 500 will then be charged at the end of each month as a one-time fee.
 
 == Changelog ==
+= 3.4.6 =
+* Error resolved where Tiny_Helpers was not available
+
 = 3.4.5 =
 * Error when mb_strimwidth is not available resolved
 

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -18,7 +18,7 @@
 * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 class Tiny_Plugin extends Tiny_WP_Base {
-	const VERSION = '3.4.5';
+	const VERSION = '3.4.6';
 	const MEDIA_COLUMN = self::NAME;
 	const DATETIME_FORMAT = 'Y-m-d G:i:s';
 

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: TinyPNG - JPEG, PNG & WebP image compression
  * Description: Speed up your website. Optimize your JPEG, PNG, and WebP images automatically with TinyPNG.
- * Version: 3.4.5
+ * Version: 3.4.6
  * Author: TinyPNG
  * Author URI: https://tinypng.com
  * Text Domain: tiny-compress-images

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -10,6 +10,7 @@
  */
 
 require dirname( __FILE__ ) . '/src/config/class-tiny-config.php';
+require dirname( __FILE__ ) . '/src/class-tiny-helpers.php';
 require dirname( __FILE__ ) . '/src/class-tiny-php.php';
 require dirname( __FILE__ ) . '/src/class-tiny-wp-base.php';
 require dirname( __FILE__ ) . '/src/class-tiny-exception.php';
@@ -20,7 +21,6 @@ require dirname( __FILE__ ) . '/src/class-tiny-image.php';
 require dirname( __FILE__ ) . '/src/class-tiny-settings.php';
 require dirname( __FILE__ ) . '/src/class-tiny-plugin.php';
 require dirname( __FILE__ ) . '/src/class-tiny-notices.php';
-require dirname( __FILE__ ) . '/src/class-tiny-helpers.php';
 require dirname( __FILE__ ) . '/src/compatibility/wpml/class-tiny-wpml.php';
 
 if ( Tiny_PHP::client_supported() ) {

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -20,6 +20,7 @@ require dirname( __FILE__ ) . '/src/class-tiny-image.php';
 require dirname( __FILE__ ) . '/src/class-tiny-settings.php';
 require dirname( __FILE__ ) . '/src/class-tiny-plugin.php';
 require dirname( __FILE__ ) . '/src/class-tiny-notices.php';
+require dirname( __FILE__ ) . '/src/class-tiny-helpers.php';
 require dirname( __FILE__ ) . '/src/compatibility/wpml/class-tiny-wpml.php';
 
 if ( Tiny_PHP::client_supported() ) {


### PR DESCRIPTION
The import wasn't added in the root plug-in file causing in internal error when an image contained an error message.
This MR will add the import and bump the version up to 3.4.6.

Error happened because I cloned using the wrong account. Then updates went to the wrong repository (should have been wcreateweb/wordpress-plugin instead of tijmenbruggeman/wordpress-plugin.