### PR TITLE
Compress images upload via JSON API

### DIFF
--- a/bin/integration-tests
+++ b/bin/integration-tests
@@ -55,7 +55,8 @@ function prepare_test_config {
 }
 
 function restore_config {
-  mv src/vendor/tinify/Tinify/Client.php.bak src/vendor/tinify/Tinify/Client.php
+mv src/config/class-tiny-config.php.bak src/config/class-tiny-config.php
+mv src/vendor/tinify/Tinify/Client.php.bak src/vendor/tinify/Tinify/Client.php
 }
 
 function start_services {

--- a/bin/run-mocks
+++ b/bin/run-mocks
@@ -7,4 +7,11 @@ MOCK_PORT=${port:-8100}
 docker build -t mock-webservice -f config/Dockerfile-mock-webservice .
 docker run -d --name tinify-mock-api -p ${MOCK_PORT}:80 -v $(pwd)/test/mock-tinypng-webservice:/var/www/html mock-webservice
 
+echo "Replacing configuration files..."
+mv src/vendor/tinify/Tinify/Client.php src/vendor/tinify/Tinify/Client.php.bak
+cp test/fixtures/Client.php src/vendor/tinify/Tinify/Client.php
+
+mv src/config/class-tiny-config.php src/config/class-tiny-config.php.bak
+cp test/fixtures/class-tiny-config.php src/config/class-tiny-config.php
+
 echo "To stop, run: bin/stop-mocks"

--- a/bin/stop-mocks
+++ b/bin/stop-mocks
@@ -1,4 +1,9 @@
 #!/bin/bash
 
+echo "Putting back configuration files..."
+mv src/config/class-tiny-config.php.bak src/config/class-tiny-config.php
+mv src/vendor/tinify/Tinify/Client.php.bak src/vendor/tinify/Tinify/Client.php
+
+echo "Shutting down containers..."
 docker stop $(docker ps -q --filter "ancestor=mock-webservice")
 docker rm $(docker ps -a -q --filter "ancestor=mock-webservice")

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -77,6 +77,13 @@ class Tiny_Settings extends Tiny_WP_Base {
 		);
 	}
 
+	public function rest_init() {
+		try {
+			$this->init_compressor();
+		} catch ( Tiny_Exception $e ) {
+		}
+	}
+
 	public function admin_init() {
 		try {
 			$this->init_compressor();

--- a/src/class-tiny-wp-base.php
+++ b/src/class-tiny-wp-base.php
@@ -56,7 +56,7 @@ abstract class Tiny_WP_Base {
 	public function __construct() {
 		add_action( 'init', $this->get_method( 'init' ) );
 		add_action( 'rest_api_init', $this->get_method( 'rest_init' ) );
-		
+
 		if ( self::is_xmlrpc_request() ) {
 			add_action( 'init', $this->get_method( 'xmlrpc_init' ) );
 		} elseif ( self::doing_ajax_request() ) {

--- a/src/class-tiny-wp-base.php
+++ b/src/class-tiny-wp-base.php
@@ -55,6 +55,8 @@ abstract class Tiny_WP_Base {
 
 	public function __construct() {
 		add_action( 'init', $this->get_method( 'init' ) );
+		add_action( 'rest_api_init', $this->get_method( 'rest_init' ) );
+		
 		if ( self::is_xmlrpc_request() ) {
 			add_action( 'init', $this->get_method( 'xmlrpc_init' ) );
 		} elseif ( self::doing_ajax_request() ) {
@@ -94,5 +96,8 @@ abstract class Tiny_WP_Base {
 	}
 
 	public function admin_menu() {
+	}
+
+	public function rest_init() {
 	}
 }

--- a/test/integration/bulkoptimization.spec.ts
+++ b/test/integration/bulkoptimization.spec.ts
@@ -121,28 +121,32 @@ test.describe('bulkoptimization', () => {
   });
 
   test('summary should display correct values', async () => {
-    await setAPIKey(page, 'PNG123');
+    await setAPIKey(page, 'JPG123');
     await setCompressionTiming(page, 'auto');
 
     await enableCompressionSizes(page, []);
-    await uploadMedia(page, 'input-example.png');
+    await uploadMedia(page, 'input-example.jpg');
 
     await enableCompressionSizes(page, ['0']);
-    await uploadMedia(page, 'input-example.png');
+    await uploadMedia(page, 'input-example.jpg');
 
-    await enableCompressionSizes(page, ['0', 'thumbnail']);
-    await uploadMedia(page, 'input-example.png');
+    await enableCompressionSizes(page, ['0', 'thumbnail', 'medium']);
+    await uploadMedia(page, 'input-example.jpg');
 
     await page.goto('/wp-admin/upload.php?page=tiny-bulk-optimization');
 
     // We uploaded 3 images
     await expect(page.locator('#uploaded-images')).toHaveText('3');
-    // 3 sizes can still be optimized, first upload original and thumbnail, second upload only thumbnail
-    await expect(page.locator('#optimizable-image-sizes')).toHaveText('3');
-    // 3 sizes are optimized, first upload original and thumbnail, second upload only original
-    await expect(page.locator('#optimized-image-sizes')).toHaveText('3');
+    await expect(page.locator('#optimizable-image-sizes')).toHaveText('5');
+    await expect(page.locator('#optimized-image-sizes')).toHaveText('4');
 
-    await expect(page.locator('#compression-progress-bar')).toHaveText('3 / 6 (50%)');
+    // Comparing byte sizes is unreliable at the moment. We need to figure out
+    // why there are differences between environments and versions.
+    // await expect(page.locator('#unoptimized-library-size')).toHaveText('3.03 MB');
+    // await expect(page.locator('#optimized-library-size')).toHaveText('2.36 MB');
+    // await expect(page.locator('#savings-percentage')).toHaveText('22.2%');
+
+    await expect(page.locator('#compression-progress-bar')).toHaveText('4 / 9 (44%)');
   });
 
   test('start bulk optimization should optimize remaining images', async () => {

--- a/test/integration/bulkoptimization.spec.ts
+++ b/test/integration/bulkoptimization.spec.ts
@@ -143,6 +143,10 @@ test.describe('bulkoptimization', () => {
       await expect(page.locator('#unoptimized-library-size')).toHaveText('3.03 MB');
       await expect(page.locator('#optimized-library-size')).toHaveText('2.36 MB');
       await expect(page.locator('#savings-percentage')).toHaveText('22.2%');
+    } else if (WPVersion < 6.0) {
+      await expect(page.locator('#unoptimized-library-size')).toHaveText('3.57 MB');
+      await expect(page.locator('#optimized-library-size')).toHaveText('2.90 MB');
+      await expect(page.locator('#savings-percentage')).toHaveText('18.9%');
     } else {
       await expect(page.locator('#unoptimized-library-size')).toHaveText('2.84 MB');
       await expect(page.locator('#optimized-library-size')).toHaveText('2.16 MB');

--- a/test/integration/bulkoptimization.spec.ts
+++ b/test/integration/bulkoptimization.spec.ts
@@ -121,38 +121,28 @@ test.describe('bulkoptimization', () => {
   });
 
   test('summary should display correct values', async () => {
-    await setAPIKey(page, 'JPG123');
+    await setAPIKey(page, 'PNG123');
     await setCompressionTiming(page, 'auto');
 
     await enableCompressionSizes(page, []);
-    await uploadMedia(page, 'input-example.jpg');
+    await uploadMedia(page, 'input-example.png');
 
     await enableCompressionSizes(page, ['0']);
-    await uploadMedia(page, 'input-example.jpg');
+    await uploadMedia(page, 'input-example.png');
 
-    await enableCompressionSizes(page, ['0', 'thumbnail', 'medium']);
-    await uploadMedia(page, 'input-example.jpg');
+    await enableCompressionSizes(page, ['0', 'thumbnail']);
+    await uploadMedia(page, 'input-example.png');
 
     await page.goto('/wp-admin/upload.php?page=tiny-bulk-optimization');
 
+    // We uploaded 3 images
     await expect(page.locator('#uploaded-images')).toHaveText('3');
-    await expect(page.locator('#optimizable-image-sizes')).toHaveText('5');
-    await expect(page.locator('#optimized-image-sizes')).toHaveText('4');
+    // 3 sizes can still be optimized, first upload original and thumbnail, second upload only thumbnail
+    await expect(page.locator('#optimizable-image-sizes')).toHaveText('3');
+    // 3 sizes are optimized, first upload original and thumbnail, second upload only original
+    await expect(page.locator('#optimized-image-sizes')).toHaveText('3');
 
-    if (WPVersion < 5.7) {
-      await expect(page.locator('#unoptimized-library-size')).toHaveText('3.03 MB');
-      await expect(page.locator('#optimized-library-size')).toHaveText('2.36 MB');
-      await expect(page.locator('#savings-percentage')).toHaveText('22.2%');
-    } else if (WPVersion < 6.0) {
-      await expect(page.locator('#unoptimized-library-size')).toHaveText('3.57 MB');
-      await expect(page.locator('#optimized-library-size')).toHaveText('2.90 MB');
-      await expect(page.locator('#savings-percentage')).toHaveText('18.9%');
-    } else {
-      await expect(page.locator('#unoptimized-library-size')).toHaveText('2.84 MB');
-      await expect(page.locator('#optimized-library-size')).toHaveText('2.16 MB');
-      await expect(page.locator('#savings-percentage')).toHaveText('23.8%');
-    }
-    await expect(page.locator('#compression-progress-bar')).toHaveText('4 / 9 (44%)');
+    await expect(page.locator('#compression-progress-bar')).toHaveText('3 / 6 (50%)');
   });
 
   test('start bulk optimization should optimize remaining images', async () => {

--- a/test/integration/compression.spec.ts
+++ b/test/integration/compression.spec.ts
@@ -458,8 +458,12 @@ test.describe('compression', () => {
     await expect(page.getByRole('button', { name: 'Compress' })).not.toBeVisible();
   });
 
-  // This is failing as images stay uncompressed
   test('compresses images upload via JSON API', async () => {
+    if (WPVersion < 4.7) {
+      // Content REST API was introduced in 4.7
+      return;
+    }
+
     await setAPIKey(page, 'JPG123');
     await setCompressionTiming(page, 'auto');
     await enableCompressionSizes(page, ['0', 'medium']);

--- a/test/integration/compression.spec.ts
+++ b/test/integration/compression.spec.ts
@@ -459,7 +459,7 @@ test.describe('compression', () => {
   });
 
   // This is failing as images stay uncompressed
-  test.skip('compresses images upload via JSON API', async () => {
+  test('compresses images upload via JSON API', async () => {
     await setAPIKey(page, 'JPG123');
     await setCompressionTiming(page, 'auto');
     await enableCompressionSizes(page, ['0', 'medium']);

--- a/test/integration/compression.spec.ts
+++ b/test/integration/compression.spec.ts
@@ -476,7 +476,7 @@ test.describe('compression', () => {
 
         const blob = new Blob([new Uint8Array(params.file)], { type: 'image/jpeg' });
 
-        const mediaResponse = await fetch(`${params.baseURL}/wp-json/wp/v2/media`, {
+        const mediaResponse = await fetch(`${params.baseURL}?rest_route=/wp/v2/media`, {
           method: 'POST',
           headers: {
             'X-WP-Nonce': nonce,

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -14,7 +14,7 @@ export async function uploadMedia(page: Page, file: string) {
 
 export async function clearMediaLibrary(page: Page) {
   await page.goto('/wp-admin/upload.php?mode=list');
-  const hasNoFiles = await page.getByText('No media files found.').isVisible();
+  const hasNoFiles = await page.getByText('No media').isVisible();
   if (hasNoFiles) {
     return;
   }

--- a/test/unit/TinySettingsAjaxTest.php
+++ b/test/unit/TinySettingsAjaxTest.php
@@ -14,12 +14,15 @@ class Tiny_Settings_Ajax_Test extends Tiny_TestCase {
 	public function test_ajax_init_should_add_actions() {
 		$this->assertEquals(array(
 				array( 'init', array( $this->subject, 'init' ) ),
+				array( 'rest_api_init', array( $this->subject, 'rest_init' ) ),
 				array( 'admin_init', array( $this->subject, 'admin_init' ) ),
 				array( 'admin_menu', array( $this->subject, 'admin_menu' ) ),
 				array( 'init', array( $this->notices, 'init' ) ),
+				array( 'rest_api_init', array( $this->notices, 'rest_init' ) ),
 				array( 'admin_init', array( $this->notices, 'admin_init' ) ),
 				array( 'admin_menu', array( $this->notices, 'admin_menu' ) ),
 				array( 'init', array( $this->notices, 'init' ) ),
+				array( 'rest_api_init', array( $this->notices, 'rest_init' ) ),
 				array( 'admin_init', array( $this->notices, 'admin_init' ) ),
 				array( 'admin_menu', array( $this->notices, 'admin_menu' ) ),
 				array( 'wp_ajax_tiny_image_sizes_notice', array( $this->subject, 'image_sizes_notice' ) ),

--- a/test/unit/TinyWpBaseTest.php
+++ b/test/unit/TinyWpBaseTest.php
@@ -14,6 +14,7 @@ class Tiny_WP_Base_Test extends Tiny_TestCase {
 	public function test_should_add_init_hooks() {
 		$this->assertEquals(array(
 				array( 'init', array( $this->subject, 'init' ) ),
+				array( 'rest_api_init', array( $this->subject, 'rest_init' ) ),
 				array( 'admin_init', array( $this->subject, 'admin_init' ) ),
 				array( 'admin_menu', array( $this->subject, 'admin_menu' ) ),
 			),


### PR DESCRIPTION
**Description**
This merge request will add an action to `rest_api_init` to create a compressor. This will ensure that images uploaded via the media endpoints (https://developer.wordpress.org/rest-api/reference/media/) are properly compressed if possible.

**Background**
Whenever an image is uploaded it will generate various sizes and call the action `wp_generate_attachment_metadata` ([link](https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/)). This action was called on uploading an image through the REST API and the `compress` function on Tiny_Image was called, though because no compressor existed in the settings the images were not compressed:
```
// class-tiny-image.php:197
public function compress() {
	if ( $this->settings->get_compressor() === null || ! $this->file_type_allowed() ) {
		return;
	}
        ...
}
```

Usually, when admin or ajax is initiated it will call the `admin_init` or `ajax_init` functions. These have methods hooked up which will create a compressor. When the request goes to the REST API, nothing was done to create the compressor. The solution was to add an action to the `rest_api_init` hook, which is called when receiving a new REST request, and make sure the compressor is created.