### PR TITLE
Remove WooCommerce compat notification

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ Make your website faster by optimizing your JPEG, PNG, and WebP images. This plu
 * Select which thumbnail sizes of an image may be optimized.
 * Multisite support with a single API key.
 * [WPML](https://wpml.org/documentation/plugins-compatibility/optimize-wordpress-images-multilingual-sites/) compatible.
-* WooCommerce compatible (see below).
+* WooCommerce compatible.
 * WP Retina 2x compatible.
 * See your usage on the settings page and during bulk optimization.
 * Color profiles are automatically translated to standard RGB color.
@@ -50,10 +50,6 @@ You can *bulk optimize* your existing JPEG, PNG, and WebP images all at once by 
 = Multisite support =
 
 The plugin is fully multisite compatible and you can set the API key for all sites by defining the key in your *wp-config.php* file. View the installation instructions for more information.
-
-= WooCommerce compatibility =
-
-This plugin is *fully compatible with WooCommerce*. However, we have discovered that WooCommerce may be trying to regenerate image attachment metadata over and over again on each page visit. If you are using WooCommerce please follow the tips from the [support section](https://wordpress.org/support/topic/woocommerce-conflict-25/). This may make your WooCommerce shop even faster than it was before.
 
 = Contact us =
 


### PR DESCRIPTION
After thorough investigation we had an issue with WooCommerce since version 3.3.3 which was resolved in version 3.3.6. This is an old version of WooCommerce and likely not used by any of our users. Therefor it is safe to remove to notification. We will document it once the GitHub repository has a Wiki.

**Background**
Customers in the past reported performance issues when having Tinify & WooCommerce installed (https://wordpress.org/support/topic/woocommerce-conflict-25/). This resulted in a workaround which is documented in the README.

This issue happened when WooCommerce introduced background thumbnail generation. They do this to improve the loading speed of the catalogue pages and certain sizes have not been resized yet:
- https://developer.woocommerce.com/2018/01/30/woocommerce-3-3-has-been-released/
- https://github.com/woocommerce/woocommerce/wiki/Thumbnail-Image-Regeneration-in-3.3  

Fortunately, Automattic (WooCommerce Authors) have resolved this issue in WooCommerce 3.6:
- Code change: https://github.com/woocommerce/woocommerce/pull/22818
- Release notes: https://developer.woocommerce.com/2019/04/01/performance-improvements-in-3-6/

I’ve tested both WooCommerce 3.3 and WooCommerce 3.6. In 3.3 every time a customer loaded the catalogue it would update the meta data causing a compression. In 3.6 this wasn’t happening anymore.
We are currently at WooCommerce 9.6. WooCommerce 3.3 was released in january 2018 and 3.6 was released in February 2019. We don’t have numbers how many customers are on 3.3, 3.4 and 3.5 but I’m guessing it is not a lot. For them we can propose the workaround if needed (https://github.com/woocommerce/woocommerce/wiki/Thumbnail-Image-Regeneration-in-3.3).