### PR TITLE
Update Tinify SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,9 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.6",
-    "facebook/webdriver": "1.1.3",
     "mikey179/vfsstream": "~1.5",
     "mockery/mockery": "~0.9",
     "phpdocumentor/reflection-docblock": "~2.0",
-    "symfony/yaml": "~2.8",
     "squizlabs/php_codesniffer": "~2.2",
     "tinify/tinify": "dev-create-key",
     "wp-coding-standards/wpcs": "0.11"

--- a/composer.lock
+++ b/composer.lock
@@ -161,34 +161,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -202,20 +200,34 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/master"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
-            "time": "2015-06-14T21:17:01+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "facebook/webdriver",
@@ -320,23 +332,24 @@
         },
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.11",
+            "version": "v1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5|^5.0"
+                "phpunit/phpunit": "^7.5||^8.5||^9.6",
+                "yoast/phpunit-polyfills": "^2.0"
             },
             "type": "library",
             "extra": {
@@ -367,7 +380,7 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2022-02-23T02:02:42+00:00"
+            "time": "2024-08-29T18:43:31+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -1372,12 +1385,12 @@
             "version": "2.9.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
                 "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
@@ -1448,36 +1461,50 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2018-11-07T22:31:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.19.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
-                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.19-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1511,7 +1538,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -1527,7 +1554,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T09:01:57+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1588,12 +1615,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/tinify/tinify-php.git",
-                "reference": "58652f928c14647a8bd4e7dc1e732f6a589afcdb"
+                "reference": "093e57b08dfa096f29951a30ac0cecbf9eb2c707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tinify/tinify-php/zipball/58652f928c14647a8bd4e7dc1e732f6a589afcdb",
-                "reference": "58652f928c14647a8bd4e7dc1e732f6a589afcdb",
+                "url": "https://api.github.com/repos/tinify/tinify-php/zipball/093e57b08dfa096f29951a30ac0cecbf9eb2c707",
+                "reference": "093e57b08dfa096f29951a30ac0cecbf9eb2c707",
                 "shasum": ""
             },
             "require": {
@@ -1603,8 +1630,7 @@
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.0"
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3"
             },
             "type": "library",
             "autoload": {
@@ -1640,7 +1666,7 @@
                 "source": "https://github.com/tinify/tinify-php/tree/create-key",
                 "issues": "https://github.com/tinify/tinify-php/issues"
             },
-            "time": "2022-09-01T10:29:52+00:00"
+            "time": "2025-02-12T09:43:20+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1693,6 +1719,6 @@
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/vendor/tinify/Tinify.php
+++ b/src/vendor/tinify/Tinify.php
@@ -2,7 +2,7 @@
 
 namespace Tinify;
 
-const VERSION = "1.5.2";
+const VERSION = "1.6.2";
 
 class Tinify {
     const AUTHENTICATED = true;

--- a/src/vendor/tinify/Tinify/Client.php
+++ b/src/vendor/tinify/Tinify/Client.php
@@ -34,7 +34,6 @@ class Client {
         $userAgent = join(" ", array_filter(array(self::userAgent(), $appIdentifier)));
 
         $this->options = array(
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => true,
             CURLOPT_USERPWD => $key ? ("api:" . $key) : NULL,
@@ -114,7 +113,7 @@ class Client {
                 $headers = self::parseHeaders(substr($response, 0, $headerSize));
                 $responseBody = substr($response, $headerSize);
 
-                if (isset($headers["compression-count"])) {
+                if ( isset($headers["compression-count"] ) ) {
                     Tinify::setCompressionCount(intval($headers["compression-count"]));
                 }
 
@@ -124,6 +123,17 @@ class Client {
 
                 if ( isset( $headers["paying-state"] ) ) {
                     Tinify::setPayingState( $headers["paying-state"] );
+                }
+
+                $details = json_decode($responseBody);
+                if (!$details) {
+                    $message = sprintf("Error while parsing response: %s (#%d)",
+                        PHP_VERSION_ID >= 50500 ? json_last_error_msg() : "Error",
+                        json_last_error());
+                    $details = (object) array(
+                        "message" => $message,
+                        "error" => "ParseError"
+                    );
                 }
 
                 if ( isset( $headers["email-address"] ) ) {

--- a/src/vendor/tinify/Tinify/ResultMeta.php
+++ b/src/vendor/tinify/Tinify/ResultMeta.php
@@ -20,4 +20,12 @@ class ResultMeta {
     public function location() {
         return isset($this->meta["location"]) ? $this->meta["location"] : null;
     }
+
+    public function extension() {
+        if (isset($this->meta["content-type"])) {
+            $parts = explode("/", $this->meta["content-type"]);
+            return end($parts);
+        }
+        return null;
+    }
 }

--- a/src/vendor/tinify/Tinify/Source.php
+++ b/src/vendor/tinify/Tinify/Source.php
@@ -42,6 +42,16 @@ class Source {
         return new Result($response->headers, $response->body);
     }
 
+    public function convert($options) {
+        $commands = array_merge($this->commands, array("convert" => $options));
+        return new self($this->url, $commands);
+    }
+
+    public function transform($options) {
+        $commands = array_merge($this->commands, array("transform" => $options));
+        return new self($this->url, $commands);
+    }
+
     public function result() {
         $response = Tinify::getClient()->request("get", $this->url, $this->commands);
         return new Result($response->headers, $response->body);


### PR DESCRIPTION
We've update the dev-create-key branch in https://github.com/tinify/tinify-php/pull/38. To update the WordPress plug-in to this version as well we need to update the composer package.

**Changes**
- Remove facebook/webdriver. This was used for the previous integration tests. The package is abanonded since 2020 (https://packagist.org/packages/facebook/webdriver)
- Remove symfony/yaml is no longer used
- Update lock, this will update the PHP SDK for Tinify which causes the code changes as we save it in the plug-in.