### PR TITLE
3.5.1 Only check for AS3CF remove local setting if plug-in is active

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Listen for XDebug",
+        "type": "php",
+        "request": "launch",
+        "port": 9003
+      }
+    ]
+  }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://tinypng.com/
 Tags: compress images, compression, image size, page speed, performance
 Requires at least: 4.0
 Tested up to: 6.7
-Stable tag: 3.5.0
+Stable tag: 3.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -127,6 +127,9 @@ A: Yes! After installing the plugin, go to *Media > Bulk Optimization*, and clic
 A: You can upgrade to a paid account by adding your *Payment details* on your [account dashboard](https://tinypng.com/dashboard/api). Additional compressions above 500 will then be charged at the end of each month as a one-time fee.
 
 == Changelog ==
+= 3.5.1 =
+* Will only check local file removal if AS3CF is active
+
 = 3.5.0 =
 * Support files uploaded through the WordPress REST API
 * Removed notification on WooCommerce incompatibility

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -18,7 +18,7 @@
 * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 class Tiny_Plugin extends Tiny_WP_Base {
-	const VERSION = '3.5.0';
+	const VERSION = '3.5.1';
 	const MEDIA_COLUMN = self::NAME;
 	const DATETIME_FORMAT = 'Y-m-d G:i:s';
 

--- a/src/compatibility/as3cf/class-tiny-as3cf.php
+++ b/src/compatibility/as3cf/class-tiny-as3cf.php
@@ -52,7 +52,13 @@ class Tiny_AS3CF {
 	}
 
 	public static function remove_local_files_setting_enabled() {
+		if ( ! Tiny_AS3CF::is_active() ) { 
+			return false;
+		}
 		$settings = get_option( 'tantan_wordpress_s3' );
+		if ( !is_array( $settings ) ) {
+			return false;
+		}
 		return array_key_exists( 'remove-local-file', $settings ) && $settings['remove-local-file'];
 	}
 

--- a/src/compatibility/as3cf/class-tiny-as3cf.php
+++ b/src/compatibility/as3cf/class-tiny-as3cf.php
@@ -52,11 +52,11 @@ class Tiny_AS3CF {
 	}
 
 	public static function remove_local_files_setting_enabled() {
-		if ( ! Tiny_AS3CF::is_active() ) { 
+		if ( ! Tiny_AS3CF::is_active() ) {
 			return false;
 		}
 		$settings = get_option( 'tantan_wordpress_s3' );
-		if ( !is_array( $settings ) ) {
+		if ( ! is_array( $settings ) ) {
 			return false;
 		}
 		return array_key_exists( 'remove-local-file', $settings ) && $settings['remove-local-file'];

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -75,6 +75,7 @@ class WordPressStubs {
 		$this->addMethod( 'current_user_can' );
 		$this->addMethod( 'wp_get_attachment_metadata' );
 		$this->addMethod( 'is_admin' );
+		$this->addMethod( 'is_plugin_active' );
 		$this->defaults();
 		$this->create_filesystem();
 	}

--- a/test/unit/compatibility/TinyAC3SFTest.php
+++ b/test/unit/compatibility/TinyAC3SFTest.php
@@ -1,0 +1,113 @@
+<?php
+
+require_once dirname(__FILE__) . '/../TinyTestCase.php';
+require_once dirname(__FILE__) . '/../../../src/compatibility/as3cf/class-tiny-as3cf.php';
+
+class Tiny_AC3SF_Test extends Tiny_TestCase
+{
+    public function set_up()
+    {
+        parent::set_up();
+    }
+
+    /**
+     * Stub is_plugin_active to return true for the pro plugin
+     * is_plugin_active will only work in admin area (after admin_init);
+     */
+    public function test_is_active_when_pro_is_enabled()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return $plugin_name === 'amazon-s3-and-cloudfront-pro/amazon-s3-and-cloudfront-pro.php';
+            }
+        );
+
+        $tiny_settings = new Tiny_Settings();
+        $tiny_ac3sf = new Tiny_AS3CF($tiny_settings);
+
+        $this->assertTrue(Tiny_AS3CF::is_active());
+    }
+
+    public function test_is_active_when_lite_is_enabled()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return $plugin_name === 'amazon-s3-and-cloudfront/wordpress-s3.php';
+            }
+        );
+
+
+        $this->assertTrue(Tiny_AS3CF::is_active());
+    }
+
+    public function test_is_not_active()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return false;
+            }
+        );
+
+
+        $this->assertFalse(Tiny_AS3CF::is_active());
+    }
+
+    public function test_remove_local_enabled_is_false_when_plugin_inactive()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return false;
+            }
+        );
+
+        $this->assertFalse(Tiny_AS3CF::remove_local_files_setting_enabled());
+    }
+
+    public function test_remove_local_false_when_option_not_exists()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return true;
+            }
+        );
+
+        $this->assertFalse(Tiny_AS3CF::remove_local_files_setting_enabled());
+    }
+
+    public function test_remove_local_false_when_option_is_false()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return true;
+            }
+        );
+
+        $this->wp->addOption('tantan_wordpress_s3', array(
+            'remove-local-file' => false,
+        ));
+
+        $this->assertFalse(Tiny_AS3CF::remove_local_files_setting_enabled());
+    }
+
+    public function test_remove_local_true_when_option_is_true()
+    {
+        $this->wp->stub(
+            'is_plugin_active',
+            function ($plugin_name) {
+                return true;
+            }
+        );
+
+        $this->wp->addOption('tantan_wordpress_s3', array(
+            'remove-local-file' => true,
+        ));
+
+        $this->assertTrue(Tiny_AS3CF::remove_local_files_setting_enabled());
+    }
+}

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: TinyPNG - JPEG, PNG & WebP image compression
  * Description: Speed up your website. Optimize your JPEG, PNG, and WebP images automatically with TinyPNG.
- * Version: 3.5.0
+ * Version: 3.5.1
  * Author: TinyPNG
  * Author URI: https://tinypng.com
  * Text Domain: tiny-compress-images


### PR DESCRIPTION
A user reported an issue where they would get an error when loading the Tinify settings page. This happened on the check if AS3CF would remove files locally. The request is done on the plug-in settings page to render a warning and only happens if the plug-in AS3CF is active.

Internally `get_option` would return `null`. This option should not return null as it contains all the settings for AS3CF. Nonetheless it returned null so there is a case where the user has not set any settings yet but has the plug-in activated.

Therefor I've added a check to see if the `get_option` returns a valid value.

- Added a check to verify if the plug-in is active
- Check if the plug-in option exists
- Added debug script for unit tests
- Added unit tests for AS3CF compatibility