### PR TITLE
When library contains no images, it will show page 1

### DIFF
--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -38,7 +38,9 @@ class Tiny_Bulk_Optimization {
 				$result = self::wpdb_retrieve_images_and_metadata( $last_image_id );
 				$stats = self::populate_optimization_statistics( $settings, $result, $stats );
 				$last_image = end( $result );
-				$last_image_id = $last_image['ID'];
+				if (isset($last_image['ID'])) {
+					$last_image_id = $last_image['ID'];
+				}
 			} while ( sizeof( $result ) == self::PAGING_SIZE );
 		} else {
 			$stats = self::populate_optimization_statistics( $settings, $result, $stats );

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -38,7 +38,7 @@ class Tiny_Bulk_Optimization {
 				$result = self::wpdb_retrieve_images_and_metadata( $last_image_id );
 				$stats = self::populate_optimization_statistics( $settings, $result, $stats );
 				$last_image = end( $result );
-				if (isset($last_image['ID'])) {
+				if ( isset( $last_image['ID'] ) ) {
 					$last_image_id = $last_image['ID'];
 				}
 			} while ( sizeof( $result ) == self::PAGING_SIZE );


### PR DESCRIPTION
When library contains no images, it would throw a warning because result would be an empty array so end returns null.

![Screenshot 2025-06-12 at 14 26 30](https://github.com/user-attachments/assets/92761889-7bc6-4acf-b13c-5401d6eb5f1c)
