### PR TITLE
Improve I18N Issues Based on 3.6.0

### DIFF
--- a/src/class-tiny-notices.php
+++ b/src/class-tiny-notices.php
@@ -281,7 +281,7 @@ class Tiny_Notices extends Tiny_WP_Base {
 			$query_string = 'action=deactivate&plugin=' . $file . '&_wpnonce=' . $nonce;
 			$url = admin_url( 'plugins.php?' . $query_string );
 			$notice .= '<a class="button button-primary" href="' . $url . '">';
-			$notice .= esc_html__( 'Deactivate' );
+			$notice .= esc_html__( 'Deactivate', 'tiny-compress-images' );
 			$notice .= '</a></td></tr>';
 		}
 		$notice .= '</table>';

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -660,9 +660,9 @@ class Tiny_Settings extends Tiny_WP_Base {
 		echo wp_kses( __( 'Resizing takes <strong>1 additional compression</strong> for each image that is larger.', 'tiny-compress-images' ), $strong ); // WPCS: Needed for proper translation.
 		echo '</span>';
 		echo '<div class="tiny-resize-inputs">';
-		printf( '%s: ', esc_html__( 'Max Width' ) );
+		printf( '%s: ', esc_html__( 'Max Width', 'tiny-compress-images' ) );
 		$this->render_resize_input( 'width' );
-		printf( '%s: ', esc_html__( 'Max Height' ) );
+		printf( '%s: ', esc_html__( 'Max Height', 'tiny-compress-images' ) );
 		$this->render_resize_input( 'height' );
 		echo '</div></div></div>';
 

--- a/src/views/account-status-connected.php
+++ b/src/views/account-status-connected.php
@@ -77,11 +77,11 @@
 			name="tinypng_api_key" size="35" spellcheck="false"
 			value="<?php echo esc_attr( $key ); ?>">
 		<button class="button button-primary" data-tiny-action="update-key"><?php
-			esc_html_e( 'Save' );
+			esc_html_e( 'Save', 'tiny-compress-images' );
 		?></button>
 		<p class="message"></p>
 		<p>
-			<a href="#" id="cancel-change-key"><?php esc_html_e( 'Cancel' ); ?></a>
+			<a href="#" id="cancel-change-key"><?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?></a>
 		</p>
 	</div>
 

--- a/src/views/account-status-create-advanced.php
+++ b/src/views/account-status-create-advanced.php
@@ -52,7 +52,7 @@ $email = trim( $user->user_email );
 		<p class="message"></p>
 
 		<button class="button button-primary" data-tiny-action="update-key">
-			<?php esc_html_e( 'Save' ); ?>
+			<?php esc_html_e( 'Save', 'tiny-compress-images' ); ?>
 		</button>
 	</div>
 </div>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -120,12 +120,12 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 		</h3>
 		<table>
 			<tr>
-				<th><?php esc_html_e( 'Size' ) ?></th>
+				<th><?php esc_html_e( 'Size', 'tiny-compress-images' ) ?></th>
 				<th><?php esc_html_e( 'Initial Size', 'tiny-compress-images' ) ?></th>
 				<th><?php esc_html_e( 'Compressed', 'tiny-compress-images' ) ?></th>
 				<th><?php esc_html_e( 'Format', 'tiny-compress-images' ) ?></th>
 				<?php if ( $conversion_enabled ) { ?> <th><?php esc_html_e( 'Converted', 'tiny-compress-images' ) ?></th> <?php } ?>
-				<th><?php esc_html_e( 'Date' ) ?></th>
+				<th><?php esc_html_e( 'Date', 'tiny-compress-images' ) ?></th>
 			</tr>
 			<?php
 			$i = 0;
@@ -168,7 +168,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 							echo '<td>' . $size->conversion_text() . '</td>';
 						}
 						/* translators: %s human friendly time difference */
-						echo '<td>' . sprintf( esc_html__( '%s ago' ), human_time_diff( $size->end_time( $size_name ) ) ) . '</td>';
+						echo '<td>' . sprintf( esc_html__( '%s ago', 'tiny-compress-images' ), human_time_diff( $size->end_time( $size_name ) ) ) . '</td>';
 					} elseif ( ! $size->exists() ) {
 						echo '<td>-</td>';
 						echo '<td colspan=4><em>' . esc_html__( 'Not present', 'tiny-compress-images' ) . '</em></td>';

--- a/src/views/settings.php
+++ b/src/views/settings.php
@@ -61,7 +61,7 @@
 			</table>
 			<p><?php echo Tiny_Plugin::request_review();?></p>
 			<p class="submit">
-				<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_html_e( 'Save Changes' ) ?>">
+				<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_html_e( 'Save Changes', 'tiny-compress-images' ) ?>">
 			</p>
 		</form>
 	</div>


### PR DESCRIPTION
1. If there are strings in your plugin that are also used in WordPress core (e.g. ‘Settings’), you should still add your text domain to them, otherwise they’ll become untranslated if the core string changes (which happens).
2. Adding Text Domain for some UI strings missing text domain.