### PR TITLE
Process Picture tags and multiple Images in a srcset

### DIFF
--- a/src/class-tiny-picture.php
+++ b/src/class-tiny-picture.php
@@ -21,14 +21,14 @@
 
 /**
  * Class responsible for parsing and modifying html to insert picture elements.
- * 
+ *
  * 1) searches for <picture> elements or <img> elements
  * 2) checks wether existing source has a modern alternative
  * 3) augments or creates a picture element
  * 4) replaces the original source with the source which includes the modern format
  */
-class Tiny_Picture extends Tiny_WP_Base
-{
+class Tiny_Picture extends Tiny_WP_Base {
+
 
 	/** @var string */
 	private $base_dir;
@@ -42,32 +42,30 @@ class Tiny_Picture extends Tiny_WP_Base
 	 * @param string $base_dir       Absolute path (e.g. ABSPATH)
 	 * @param array  $domains        List of allowed domain URLs
 	 */
-	function __construct($base_dir = ABSPATH, $domains = array())
-	{
+	function __construct( $base_dir = ABSPATH, $domains = array() ) {
 		$this->base_dir        = $base_dir;
 		$this->allowed_domains = $domains;
 
-		if (is_admin() || is_customize_preview()) {
+		if ( is_admin() || is_customize_preview() ) {
 			return;
 		}
 
-		if (defined('DOING_AJAX') && DOING_AJAX) {
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}
 
-		if (defined('DOING_CRON') && DOING_CRON) {
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 			return;
 		}
 
 		add_action('template_redirect', function () {
-			ob_start(array($this, 'replace_sources'), 1000);
+			ob_start( array( $this, 'replace_sources' ), 1000 );
 		});
 	}
 
-	public function replace_sources($content)
-	{
-		$content = $this->replace_picture_sources($content);
-		$content = $this->replace_img_sources($content);
+	public function replace_sources( $content ) {
+		$content = $this->replace_picture_sources( $content );
+		$content = $this->replace_img_sources( $content );
 
 		return $content;
 	}
@@ -78,20 +76,18 @@ class Tiny_Picture extends Tiny_WP_Base
 	 * @param string $content
 	 * @return string the new source html
 	 */
-	private function replace_picture_sources($content)
-	{
-		$picture_sources = $this->filter_pictures($content);
-		foreach ($picture_sources as $picture_source) {
-			$content = $this->replace_picture($content, $picture_source);
+	private function replace_picture_sources( $content ) {
+		$picture_sources = $this->filter_pictures( $content );
+		foreach ( $picture_sources as $picture_source ) {
+			$content = $this->replace_picture( $content, $picture_source );
 		}
 		return $content;
 	}
 
-	private function replace_img_sources($content)
-	{
-		$image_sources = $this->filter_images($content);
-		foreach ($image_sources as $image_source) {
-			$content = Tiny_Picture::replace_image($content, $image_source);
+	private function replace_img_sources( $content ) {
+		$image_sources = $this->filter_images( $content );
+		foreach ( $image_sources as $image_source ) {
+			$content = Tiny_Picture::replace_image( $content, $image_source );
 		}
 		return $content;
 	}
@@ -102,8 +98,7 @@ class Tiny_Picture extends Tiny_WP_Base
 	 * @param string $content
 	 * @return array<Tiny_Picture_Source> an array of picture element sources
 	 */
-	private function filter_pictures($content)
-	{
+	private function filter_pictures( $content ) {
 		$matches = array();
 		/*
 		 * Match <picture> blocks that contain one or more <source> tags.
@@ -114,17 +109,17 @@ class Tiny_Picture extends Tiny_WP_Base
 		 * - (?:<source[^>]*?>)+: one or more <source> tags inside the picture.
 		 * - (?:.*?</picture>)?: optionally include everything up to the closing
 		 *   </picture>.
-		 *
-		 * Modifiers:
-		 * - i: case-insensitive.
-		 * - s: dot matches newlines.
 		 */
-		if (! preg_match_all('#(?:<picture[^>]*?>\s*)(?:<source[^>]*?>)+(?:.*?</picture>)?#is', $content, $matches)) {
+		if ( ! preg_match_all(
+			'#(?:<picture[^>]*?>\s*)(?:<source[^>]*?>)+(?:.*?</picture>)?#is',
+			$content,
+			$matches
+		) ) {
 			return array();
 		}
 
 		$pictures = array();
-		foreach ($matches[0] as $raw_picture) {
+		foreach ( $matches[0] as $raw_picture ) {
 			$pictures[] = new Tiny_Picture_Source(
 				$raw_picture,
 				$this->base_dir,
@@ -137,30 +132,28 @@ class Tiny_Picture extends Tiny_WP_Base
 
 	/**
 	 * Will add additional sourcesets to picture elements.
-	 * 
+	 *
 	 * @param string $content the full page content
 	 * @param Tiny_Picture_Source $source the picture element
-	 * 
+	 *
 	 * @return string the updated content including augmented picture elements
 	 */
-	private function replace_picture($content, $source)
-	{
-		$content = str_replace($source->raw_html, $source->augment_picture_element(), $content);
+	private function replace_picture( $content, $source ) {
+		$content = str_replace( $source->raw_html, $source->augment_picture_element(), $content );
 		return $content;
 	}
 
 
 	/**
 	 * Will replace img elements with picture elements that (possibly) have additional formats.
-	 * 
+	 *
 	 * @param string $content the full page content
 	 * @param Tiny_Image_Source $source the picture element
-	 * 
+	 *
 	 * @return string the updated content including augmented picture elements
 	 */
-	private static function replace_image($content, $source)
-	{
-		$content = str_replace($source->raw_html, $source->create_picture_elements(), $content);
+	private static function replace_image( $content, $source ) {
+		$content = str_replace( $source->raw_html, $source->create_picture_elements(), $content );
 		return $content;
 	}
 
@@ -169,30 +162,28 @@ class Tiny_Picture extends Tiny_WP_Base
 	 *
 	 * @return Tiny_Image[]
 	 */
-	private function filter_images($content)
-	{
+	private function filter_images( $content ) {
 		// Extract only the <body>...</body> section.
-		if (preg_match('/(?=<body).*<\/body>/is', $content, $body)) {
+		if ( preg_match( '/(?=<body).*<\/body>/is', $content, $body ) ) {
 			$content = $body[0];
 		}
 
 		// strip HTML comments.
-		$content = preg_replace('/<!--(.*)-->/Uis', '', $content);
+		$content = preg_replace( '/<!--(.*)-->/Uis', '', $content );
 
 		// strip existing <picture> blocks to avoid double-processing.
-		$content = preg_replace('/<picture\b.*?>.*?<\/picture>/is', '', $content);
+		$content = preg_replace( '/<picture\b.*?>.*?<\/picture>/is', '', $content );
 
 		// Strip <noscript> blocks to avoid altering their contents.
-		$content = preg_replace('/<noscript\b.*?>.*?<\/noscript>/is', '', $content);
-
+		$content = preg_replace( '/<noscript\b.*?>.*?<\/noscript>/is', '', $content );
 
 		// Find all <img> tags with any attributes.
-		if (!preg_match_all('/<img\b[^>]*>/is', $content, $matches)) {
+		if ( ! preg_match_all( '/<img\b[^>]*>/is', $content, $matches ) ) {
 			return array();
 		}
 
 		$images = array();
-		foreach ($matches[0] as $img) {
+		foreach ( $matches[0] as $img ) {
 			$images[] = new Tiny_Image_Source(
 				$img,
 				$this->base_dir,
@@ -204,64 +195,60 @@ class Tiny_Picture extends Tiny_WP_Base
 	}
 }
 
-abstract class Tiny_Source_Base
-{
+abstract class Tiny_Source_Base {
+
 	public $raw_html;
 	protected $base_dir;
 	protected $allowed_domains;
 	protected $valid_mimetypes;
 
-	public function __construct($html, $base_dir, $domains)
-	{
+	public function __construct( $html, $base_dir, $domains ) {
 		$this->raw_html 	   = $html;
 		$this->base_dir        = $base_dir;
 		$this->allowed_domains = $domains;
-		$this->valid_mimetypes = array('image/webp', 'image/avif');
+		$this->valid_mimetypes = array( 'image/webp', 'image/avif' );
 	}
 
-	protected static function get_attribute_value($element, $name)
-	{
+	protected static function get_attribute_value( $element, $name ) {
 		// Find {name} enclosed in single or double quotes after '='
-		$regex = '#\b' . preg_quote($name, '#') . '\s*=\s*(["\'])(.*?)\1#is';
-		if (preg_match($regex, $element, $attr_matches)) {
+		$regex = '#\b' . preg_quote( $name, '#' ) . '\s*=\s*(["\'])(.*?)\1#is';
+		if ( preg_match( $regex, $element, $attr_matches ) ) {
 			return $attr_matches[2];
 		}
 		return null;
 	}
 
-	protected function get_local_path($url)
-	{
-		if (strpos($url, 'http') === 0) {
+	protected function get_local_path( $url ) {
+		if ( strpos( $url, 'http' ) === 0 ) {
 			$matched_domain = null;
 
-			foreach ($this->allowed_domains as $domain) {
-				if (strpos($url, $domain) === 0) {
+			foreach ( $this->allowed_domains as $domain ) {
+				if ( strpos( $url, $domain ) === 0 ) {
 					$matched_domain = $domain;
 					break;
 				}
 			}
 
-			if (null === $matched_domain) {
+			if ( null === $matched_domain ) {
 				return '';
 			}
 
-			$url = substr($url, strlen($matched_domain));
+			$url = substr( $url, strlen( $matched_domain ) );
 		}
 		$url = $this->base_dir . $url;
 
 		return $url;
 	}
 
-	protected function get_formatted_source($image_source_data, $mimetype)
-	{
-		$format_url = Tiny_Helpers::replace_file_extension($mimetype, $image_source_data['path']);
-		$local_path = $this->get_local_path($format_url);
-		if (empty($local_path)) {
+	protected function get_formatted_source( $image_source_data, $mimetype ) {
+		$format_url = Tiny_Helpers::replace_file_extension( $mimetype, $image_source_data['path'] );
+		$local_path = $this->get_local_path( $format_url );
+		if ( empty( $local_path ) ) {
 			return null;
 		}
 
-		$exists_local = file_exists($local_path);
-		if ($exists_local) {
+		$exists_local = file_exists( $local_path );
+		if ( $exists_local ) {
 			return array(
 				'src' => $format_url,
 				'size' => $image_source_data['size'],
@@ -271,14 +258,18 @@ abstract class Tiny_Source_Base
 		return null;
 	}
 
-	protected function build_alternative_sources_for_url($url, $size = '')
-	{
+	protected function build_alternative_sources_for_url( $url, $size = '' ) {
 		$sources = array();
-		foreach ($this->valid_mimetypes as $mimetype) {
-			$formatted = $this->get_formatted_source(array('path' => $url, 'size' => $size), $mimetype);
-			if ($formatted) {
-				$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
-				$sources[] = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '" />';
+		foreach ( $this->valid_mimetypes as $mimetype ) {
+			$formatted = $this->get_formatted_source( array(
+				'path' => $url,
+				'size' => $size,
+			), $mimetype );
+			if ( $formatted ) {
+				$srcset = trim( $formatted['src'] . ' ' . $formatted['size'] );
+				$sources[] = '<source srcset="' .
+					$srcset . '" type="' .
+					$formatted['type'] . '" />';
 				break;
 			}
 		}
@@ -291,50 +282,55 @@ abstract class Tiny_Source_Base
 	 * @param string $srcset
 	 * @return array{ path: string, size: string } srcset parts
 	 */
-	protected static function parse_srcset_list($srcset)
-	{
+	protected static function parse_srcset_list( $srcset ) {
 		$out = [];
-		foreach (explode(',', $srcset) as $entry) {
-			$entry = trim($entry);
-			if ($entry === '') continue;
-			$parts = preg_split('/\s+/', $entry, 2);
-			$out[] = ['path' => $parts[0], 'size' => $parts[1] ?? ''];
+		foreach ( explode( ',', $srcset ) as $entry ) {
+			$entry = trim( $entry );
+			if ( '' === $entry ) {
+				continue;
+			}
+			$parts = preg_split( '/\s+/', $entry, 2 );
+			$out[] = [
+				'path' => $parts[0],
+				'size' => $parts[1] ?? '',
+			];
 		}
 		return $out;
 	}
 }
 
-class Tiny_Picture_Source extends Tiny_Source_Base
-{
+class Tiny_Picture_Source extends Tiny_Source_Base {
+
 
 	/**
 	 * Adds alternative format sources (e.g., image/webp, image/avif) to an existing
 	 * <picture> element based on locally available converted files.
-	 * 
+	 *
 	 *
 	 * @return string The augmented <picture> HTML or the original if no additions.
 	 */
-	public function augment_picture_element()
-	{
+	public function augment_picture_element() {
 		$new_sources = array();
 
 		// Find existing <source> tags inside the <picture>.
-		if (preg_match_all('#<source\b[^>]*>#i', $this->raw_html, $source_tag_matches)) {
-			foreach ($source_tag_matches[0] as $source_tag_html) {
+		if ( preg_match_all( '#<source\b[^>]*>#i', $this->raw_html, $source_tag_matches ) ) {
+			foreach ( $source_tag_matches[0] as $source_tag_html ) {
 				// Extract srcset="..."
-				if (!preg_match('#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $m)) continue;
+				if ( ! preg_match( '#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $m ) ) { continue;
+				}
 				$media = '';
 				// Extract optional media="..." to preserve any media query
-				if (preg_match('#\bmedia\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $mm)) {
+				if ( preg_match( '#\bmedia\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $mm ) ) {
 					$media = $mm[2];
 				}
-				foreach (self::parse_srcset_list($m[2]) as $entry) {
-					foreach ($this->valid_mimetypes as $mimetype) {
-						$formatted = $this->get_formatted_source($entry, $mimetype);
-						if ($formatted) {
-							$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
+				foreach ( self::parse_srcset_list( $m[2] ) as $entry ) {
+					foreach ( $this->valid_mimetypes as $mimetype ) {
+						$formatted = $this->get_formatted_source( $entry, $mimetype );
+						if ( $formatted ) {
+							$srcset = trim( $formatted['src'] . ' ' . $formatted['size'] );
 							$tag = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '"';
-							if ($media) $tag .= ' media="' . $media . '"';
+							if ( $media ) { $tag .= ' media="' . $media . '"';
+							}
 							$new_sources[] = $tag . ' />';
 							break;
 						}
@@ -344,69 +340,71 @@ class Tiny_Picture_Source extends Tiny_Source_Base
 		}
 
 		// inner <img>
-		if (preg_match('#<img\b[^>]*>#i', $this->raw_html, $img_tag_match)) {
+		if ( preg_match( '#<img\b[^>]*>#i', $this->raw_html, $img_tag_match ) ) {
 			$img_tag = $img_tag_match[0];
 			$candidates = [];
 			// Extract srcset="..."
-			if (preg_match('#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m)) {
-				$candidates = array_merge($candidates, self::parse_srcset_list($m[2]));
+			if ( preg_match( '#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m ) ) {
+				$candidates = array_merge( $candidates, self::parse_srcset_list( $m[2] ) );
 			}
 			// Extract fallback src="..."
-			if (preg_match('#\bsrc\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m)) {
-				$candidates[] = ['path' => $m[2], 'size' => ''];
+			if ( preg_match( '#\bsrc\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m ) ) {
+				$candidates[] = [
+					'path' => $m[2],
+					'size' => '',
+				];
 			}
-			foreach ($candidates as $entry) {
-				foreach ($this->valid_mimetypes as $mimetype) {
-					$formatted = $this->get_formatted_source($entry, $mimetype);
-					if ($formatted) {
-						$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
+			foreach ( $candidates as $entry ) {
+				foreach ( $this->valid_mimetypes as $mimetype ) {
+					$formatted = $this->get_formatted_source( $entry, $mimetype );
+					if ( $formatted ) {
+						$srcset = trim( $formatted['src'] . ' ' . $formatted['size'] );
 						$new_sources[] = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '" />';
 						break;
 					}
 				}
 			}
 		}
-		if (empty($new_sources)) {
+		if ( empty( $new_sources ) ) {
 			return $this->raw_html;
 		}
 
-		$insertion = implode('', $new_sources);
+		$insertion = implode( '', $new_sources );
 
 		// Insert newly built <source> elements immediately before the first <img>
-		return preg_replace('#(<img\b)#i', $insertion . '$1', $this->raw_html, 1);
+		return preg_replace( '#(<img\b)#i', $insertion . '$1', $this->raw_html, 1 );
 	}
 }
 
-class Tiny_Image_Source extends Tiny_Source_Base
-{
+class Tiny_Image_Source extends Tiny_Source_Base {
+
 	/**
 	 * Retrieves the image sources from the img element
 	 *
 	 * @return array{path: string, size: string}[] The image sources
 	 */
-	private function get_image_srcsets()
-	{
+	private function get_image_srcsets() {
 		$result = array();
-		$srcset = $this::get_attribute_value($this->raw_html, 'srcset');
+		$srcset = $this::get_attribute_value( $this->raw_html, 'srcset' );
 
-		if ($srcset) {
+		if ( $srcset ) {
 			// Split the srcset to get individual entries
-			$srcset_entries = explode(',', $srcset);
+			$srcset_entries = explode( ',', $srcset );
 
-			foreach ($srcset_entries as $entry) {
+			foreach ( $srcset_entries as $entry ) {
 				// Trim whitespace
-				$entry = trim($entry);
+				$entry = trim( $entry );
 
 				// Split by whitespace to separate path and size descriptor
-				$parts = preg_split('/\s+/', $entry, 2);
+				$parts = preg_split( '/\s+/', $entry, 2 );
 
-				if (count($parts) === 2) {
+				if ( count( $parts ) === 2 ) {
 					// We have both path and size
 					$result[] = array(
 						'path' => $parts[0],
 						'size' => $parts[1],
 					);
-				} elseif (count($parts) === 1) {
+				} elseif ( count( $parts ) === 1 ) {
 					// We only have a path (unusual in srcset)
 					$result[] = array(
 						'path' => $parts[0],
@@ -416,8 +414,8 @@ class Tiny_Image_Source extends Tiny_Source_Base
 			}
 		}
 
-		$source = $this::get_attribute_value($this->raw_html, 'src');
-		if (! empty($source)) {
+		$source = $this::get_attribute_value( $this->raw_html, 'src' );
+		if ( ! empty( $source ) ) {
 			// No srcset, but we have a src attribute
 			$result[] = array(
 				'path' => $source,
@@ -435,43 +433,41 @@ class Tiny_Image_Source extends Tiny_Source_Base
 	 * specified MIME type, resolves the local path of the resulting file, and returns
 	 * the `srcset` and `type` if the file exists.
 	 *
-	 * @param array  $imgsrc   An associative array containing at least the keys 'path'
-	 * 						   (string) and 'size' (string).
-	 * @param string $mimetype The target MIME type (e.g., 'image/webp', 'image/avif').
-	 *
-	 * @return array|null An array with 'srcset' and 'type' if the file exists locally,
-	 * 					  or null otherwise.
+	 * @return string a <picture> element contain additional sources
 	 */
-
-	public function create_picture_elements()
-	{
+	public function create_picture_elements() {
 		$srcsets = $this->get_image_srcsets();
-
-		$srcset_parts = array();
-		foreach ($srcsets as $srcset) {
-			foreach ($this->valid_mimetypes as $mimetype) {
-				$new_srcset = $this->get_formatted_source($srcset, $mimetype);
-
-				if ($new_srcset) {
-					$srcset_parts[] = $new_srcset;
-					break;
-				}
-			}
-		}
-
-		if (empty($srcset_parts)) {
+		if ( empty( $srcsets ) ) {
 			return $this->raw_html;
 		}
 
-		$picture_element = array('<picture>');
-		foreach ($srcset_parts as $source_part) {
-			$srcset = trim($source_part['src'] . ' ' . $source_part['size']);
-			$picture_element[] =
-				'<source srcset="' . $srcset . '" type="' . $source_part['type'] . '" />';
+		$sources = array();
+		foreach ( $this->valid_mimetypes as $mimetype ) {
+			$srcset_parts = [];
+
+			foreach ( $srcsets as $srcset ) {
+				$alt_source = $this->get_formatted_source( $srcset, $mimetype );
+				if ( $alt_source ) {
+					$srcset_parts[] = trim( $alt_source['src'] . ' ' . $alt_source['size'] );
+				}
+			}
+
+			if ( ! empty( $srcset_parts ) ) {
+				$srcset_attr = implode( ', ', $srcset_parts );
+				$mimetype_source = '<source srcset="' . $srcset_attr . '" type="' . $mimetype . '" />';
+				$sources[] = $mimetype_source;
+			}
 		}
+
+		if ( empty( $sources ) ) {
+			return $this->raw_html;
+		}
+
+		$picture_element = array( '<picture>' );
+		$picture_element[] = implode( '', $sources );
 		$picture_element[] = $this->raw_html;
 		$picture_element[] = '</picture>';
 
-		return implode('', $picture_element);
+		return implode( '', $picture_element );
 	}
 }

--- a/src/class-tiny-picture.php
+++ b/src/class-tiny-picture.php
@@ -18,7 +18,17 @@
 * with this program; if not, write to the Free Software Foundation, Inc., 51
 * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-class Tiny_Picture extends Tiny_WP_Base {
+
+/**
+ * Class responsible for parsing and modifying html to insert picture elements.
+ * 
+ * 1) searches for <picture> elements or <img> elements
+ * 2) checks wether existing source has a modern alternative
+ * 3) augments or creates a picture element
+ * 4) replaces the original source with the source which includes the modern format
+ */
+class Tiny_Picture extends Tiny_WP_Base
+{
 
 	/** @var string */
 	private $base_dir;
@@ -32,37 +42,125 @@ class Tiny_Picture extends Tiny_WP_Base {
 	 * @param string $base_dir       Absolute path (e.g. ABSPATH)
 	 * @param array  $domains        List of allowed domain URLs
 	 */
-	function __construct( $base_dir = ABSPATH, $domains = array() ) {
+	function __construct($base_dir = ABSPATH, $domains = array())
+	{
 		$this->base_dir        = $base_dir;
 		$this->allowed_domains = $domains;
 
-		if ( is_admin() || is_customize_preview() ) {
+		if (is_admin() || is_customize_preview()) {
 			return;
 		}
 
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		if (defined('DOING_AJAX') && DOING_AJAX) {
 			return;
 		}
 
-		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+		if (defined('DOING_CRON') && DOING_CRON) {
 			return;
 		}
 
-		add_action( 'template_redirect', function() {
-			ob_start( array( $this, 'replace_img_sources' ), 1000 );
+		add_action('template_redirect', function () {
+			ob_start(array($this, 'replace_sources'), 1000);
 		});
 	}
 
-	public function replace_img_sources( $content ) {
-		$image_sources = $this->filter_images( $content );
-		foreach ( $image_sources as $image_source ) {
-			$content = Tiny_Picture::replace_image( $content, $image_source );
+	public function replace_sources($content)
+	{
+		$content = $this->replace_picture_sources($content);
+		$content = $this->replace_img_sources($content);
+
+		return $content;
+	}
+
+	/**
+	 * Will extend existing picture elements with additional sourcesets
+	 *
+	 * @param string $content
+	 * @return string the new source html
+	 */
+	private function replace_picture_sources($content)
+	{
+		$picture_sources = $this->filter_pictures($content);
+		foreach ($picture_sources as $picture_source) {
+			$content = $this->replace_picture($content, $picture_source);
 		}
 		return $content;
 	}
 
-	private static function replace_image( $content, $source ) {
-		$content = str_replace( $source->image, $source->create_picture_elements(), $content );
+	private function replace_img_sources($content)
+	{
+		$image_sources = $this->filter_images($content);
+		foreach ($image_sources as $image_source) {
+			$content = Tiny_Picture::replace_image($content, $image_source);
+		}
+		return $content;
+	}
+
+	/**
+	 * Will search for all picture elements within the given source html
+	 *
+	 * @param string $content
+	 * @return array<Tiny_Picture_Source> an array of picture element sources
+	 */
+	private function filter_pictures($content)
+	{
+		$matches = array();
+		/*
+		 * Match <picture> blocks that contain one or more <source> tags.
+		 *
+		 * Pattern parts:
+		 * - (?:<picture[^>]*?>\s*): opening <picture> with optional attributes and
+		 *   trailing whitespace.
+		 * - (?:<source[^>]*?>)+: one or more <source> tags inside the picture.
+		 * - (?:.*?</picture>)?: optionally include everything up to the closing
+		 *   </picture>.
+		 *
+		 * Modifiers:
+		 * - i: case-insensitive.
+		 * - s: dot matches newlines.
+		 */
+		if (! preg_match_all('#(?:<picture[^>]*?>\s*)(?:<source[^>]*?>)+(?:.*?</picture>)?#is', $content, $matches)) {
+			return array();
+		}
+
+		$pictures = array();
+		foreach ($matches[0] as $raw_picture) {
+			$pictures[] = new Tiny_Picture_Source(
+				$raw_picture,
+				$this->base_dir,
+				$this->allowed_domains
+			);
+		}
+
+		return $pictures;
+	}
+
+	/**
+	 * Will add additional sourcesets to picture elements.
+	 * 
+	 * @param string $content the full page content
+	 * @param Tiny_Picture_Source $source the picture element
+	 * 
+	 * @return string the updated content including augmented picture elements
+	 */
+	private function replace_picture($content, $source)
+	{
+		$content = str_replace($source->raw_html, $source->augment_picture_element(), $content);
+		return $content;
+	}
+
+
+	/**
+	 * Will replace img elements with picture elements that (possibly) have additional formats.
+	 * 
+	 * @param string $content the full page content
+	 * @param Tiny_Image_Source $source the picture element
+	 * 
+	 * @return string the updated content including augmented picture elements
+	 */
+	private static function replace_image($content, $source)
+	{
+		$content = str_replace($source->raw_html, $source->create_picture_elements(), $content);
 		return $content;
 	}
 
@@ -71,21 +169,30 @@ class Tiny_Picture extends Tiny_WP_Base {
 	 *
 	 * @return Tiny_Image[]
 	 */
-	private function filter_images( $content ) {
-		if ( preg_match( '/(?=<body).*<\/body>/is', $content, $body ) ) {
+	private function filter_images($content)
+	{
+		// Extract only the <body>...</body> section.
+		if (preg_match('/(?=<body).*<\/body>/is', $content, $body)) {
 			$content = $body[0];
 		}
 
-		$content = preg_replace( '/<!--(.*)-->/Uis', '', $content );
+		// strip HTML comments.
+		$content = preg_replace('/<!--(.*)-->/Uis', '', $content);
 
-		$content = preg_replace( '#<noscript(.*?)>(.*?)</noscript>#is', '', $content );
+		// strip existing <picture> blocks to avoid double-processing.
+		$content = preg_replace('/<picture\b.*?>.*?<\/picture>/is', '', $content);
 
-		if ( ! preg_match_all( '/<img\s.*>/isU', $content, $matches ) ) {
+		// Strip <noscript> blocks to avoid altering their contents.
+		$content = preg_replace('/<noscript\b.*?>.*?<\/noscript>/is', '', $content);
+
+
+		// Find all <img> tags with any attributes.
+		if (!preg_match_all('/<img\b[^>]*>/is', $content, $matches)) {
 			return array();
 		}
 
 		$images = array();
-		foreach ( $matches[0] as $img ) {
+		foreach ($matches[0] as $img) {
 			$images[] = new Tiny_Image_Source(
 				$img,
 				$this->base_dir,
@@ -95,144 +202,211 @@ class Tiny_Picture extends Tiny_WP_Base {
 
 		return $images;
 	}
-
-	/**
-	 * Replace attachment URL with .avif/.webp variant if supported and exists.
-	*
-	* @see https://developer.wordpress.org/reference/hooks/wp_get_attachment_url/
-	*
-	* @param string $url     Original attachment URL.
-	* @param int    $post_id Attachment post ID.
-	* @return string New or original URL.
-	*/
-	public function filter_attachment_url( $url, $post_id ) {
-		$supported_formats = $this->get_support_formats();
-		if ( empty( $supported_formats ) ) {
-			return $url;
-		}
-
-		$uploads = wp_upload_dir();
-		$basedir = trailingslashit( $uploads['basedir'] );
-		$baseurl = trailingslashit( $uploads['baseurl'] );
-
-		$relative = str_replace( $baseurl, '', $url );
-		$path     = $basedir . $relative;
-
-		foreach ( $supported_formats as $format ) {
-			$candidate = preg_replace( '/\.(jpe?g|png|webp)$/i', $format['ext'], $path );
-			if ( file_exists( $candidate ) ) {
-				return $baseurl . ltrim( str_replace( $basedir, '', $candidate ), '/' );
-			}
-		}
-		return $url;
-	}
-
-	/**
-	 * Swap URL in <img> tags.
-	 *
-	 * @param array|false $image         [0]=URL, [1]=width, [2]=height, [3]=is_intermediate
-	 * @param int         $attachment_id Attachment ID.
-	 * @param string|int[] $size         Size name or [width,height].
-	 * @param bool        $icon          Whether icon fallback.
-	 * @return array|false Modified image array.
-	 */
-	public function filter_attachment_image_src( $image, $attachment_id, $size, $icon ) {
-		if ( ! $image ) {
-			return $image;
-		}
-		list( $url, $w, $h, $inter ) = $image;
-		$new_url = $this->filter_attachment_url( $url, $attachment_id );
-		return [ $new_url, $w, $h, $inter ];
-	}
-
-	/**
-	 * Swap URLs in responsive srcset.
-	 *
-	 * @param array   $sources       Array of [ 'url'=>..., 'descriptor'=>..., 'value'=>... ]
-	 * @param int[]   $size_array    [width, height]
-	 * @param string  $image_src     Original src
-	 * @param array   $image_meta    Attachment metadata
-	 * @param int     $attachment_id Attachment ID
-	 * @return array Modified sources array.
-	 */
-	public function filter_image_srcset(
-		$sources,
-		$size_array,
-		$image_src,
-		$image_meta,
-		$attachment_id
-	) {
-		foreach ( $sources as &$src ) {
-			$src['url'] = $this->filter_attachment_url( $src['url'], $attachment_id );
-		}
-		return $sources;
-	}
 }
 
+abstract class Tiny_Source_Base
+{
+	public $raw_html;
+	protected $base_dir;
+	protected $allowed_domains;
+	protected $valid_mimetypes;
 
-class Tiny_Image_Source {
-	/**
-	 * The raw HTML img element as a string
-	 * @var string
-	 */
-	public $image;
-
-	private $base_dir;
-
-	private $allowed_domains;
-
-	private $valid_mimetypes;
-
-
-	public function __construct( $img_element, $base_dir, $domains ) {
-		$this->image = $img_element;
-		$this->base_dir = $base_dir;
+	public function __construct($html, $base_dir, $domains)
+	{
+		$this->raw_html 	   = $html;
+		$this->base_dir        = $base_dir;
 		$this->allowed_domains = $domains;
-		$this->valid_mimetypes = array( 'image/webp', 'image/avif' );
+		$this->valid_mimetypes = array('image/webp', 'image/avif');
 	}
 
-	/**
-	 * Attempts to get an HTML attribute from the given string
-	 *
-	 * @param string $html The string to parse
-	 * @param string $attribute_name The name of the attribute to search for.
-	 * @return string The value of the attribute, or an empty string if not found.
-	 */
-	private static function get_attribute_value( $element, $name ) {
-		$regex = '#\b' . preg_quote( $name, '#' ) . '\s*=\s*(["\'])(.*?)\1#is';
-		if ( preg_match( $regex, $element, $attr_matches ) ) {
+	protected static function get_attribute_value($element, $name)
+	{
+		// Find {name} enclosed in single or double quotes after '='
+		$regex = '#\b' . preg_quote($name, '#') . '\s*=\s*(["\'])(.*?)\1#is';
+		if (preg_match($regex, $element, $attr_matches)) {
 			return $attr_matches[2];
 		}
 		return null;
 	}
 
+	protected function get_local_path($url)
+	{
+		if (strpos($url, 'http') === 0) {
+			$matched_domain = null;
+
+			foreach ($this->allowed_domains as $domain) {
+				if (strpos($url, $domain) === 0) {
+					$matched_domain = $domain;
+					break;
+				}
+			}
+
+			if (null === $matched_domain) {
+				return '';
+			}
+
+			$url = substr($url, strlen($matched_domain));
+		}
+		$url = $this->base_dir . $url;
+
+		return $url;
+	}
+
+	protected function get_formatted_source($image_source_data, $mimetype)
+	{
+		$format_url = Tiny_Helpers::replace_file_extension($mimetype, $image_source_data['path']);
+		$local_path = $this->get_local_path($format_url);
+		if (empty($local_path)) {
+			return null;
+		}
+
+		$exists_local = file_exists($local_path);
+		if ($exists_local) {
+			return array(
+				'src' => $format_url,
+				'size' => $image_source_data['size'],
+				'type' => $mimetype,
+			);
+		}
+		return null;
+	}
+
+	protected function build_alternative_sources_for_url($url, $size = '')
+	{
+		$sources = array();
+		foreach ($this->valid_mimetypes as $mimetype) {
+			$formatted = $this->get_formatted_source(array('path' => $url, 'size' => $size), $mimetype);
+			if ($formatted) {
+				$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
+				$sources[] = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '" />';
+				break;
+			}
+		}
+		return $sources;
+	}
+
+	/**
+	 * Will parse the srcset attribute
+	 *
+	 * @param string $srcset
+	 * @return array{ path: string, size: string } srcset parts
+	 */
+	protected static function parse_srcset_list($srcset)
+	{
+		$out = [];
+		foreach (explode(',', $srcset) as $entry) {
+			$entry = trim($entry);
+			if ($entry === '') continue;
+			$parts = preg_split('/\s+/', $entry, 2);
+			$out[] = ['path' => $parts[0], 'size' => $parts[1] ?? ''];
+		}
+		return $out;
+	}
+}
+
+class Tiny_Picture_Source extends Tiny_Source_Base
+{
+
+	/**
+	 * Adds alternative format sources (e.g., image/webp, image/avif) to an existing
+	 * <picture> element based on locally available converted files.
+	 * 
+	 *
+	 * @return string The augmented <picture> HTML or the original if no additions.
+	 */
+	public function augment_picture_element()
+	{
+		$new_sources = array();
+
+		// Find existing <source> tags inside the <picture>.
+		if (preg_match_all('#<source\b[^>]*>#i', $this->raw_html, $source_tag_matches)) {
+			foreach ($source_tag_matches[0] as $source_tag_html) {
+				// Extract srcset="..."
+				if (!preg_match('#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $m)) continue;
+				$media = '';
+				// Extract optional media="..." to preserve any media query
+				if (preg_match('#\bmedia\s*=\s*([\"\'])(.*?)\1#i', $source_tag_html, $mm)) {
+					$media = $mm[2];
+				}
+				foreach (self::parse_srcset_list($m[2]) as $entry) {
+					foreach ($this->valid_mimetypes as $mimetype) {
+						$formatted = $this->get_formatted_source($entry, $mimetype);
+						if ($formatted) {
+							$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
+							$tag = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '"';
+							if ($media) $tag .= ' media="' . $media . '"';
+							$new_sources[] = $tag . ' />';
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		// inner <img>
+		if (preg_match('#<img\b[^>]*>#i', $this->raw_html, $img_tag_match)) {
+			$img_tag = $img_tag_match[0];
+			$candidates = [];
+			// Extract srcset="..."
+			if (preg_match('#\bsrcset\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m)) {
+				$candidates = array_merge($candidates, self::parse_srcset_list($m[2]));
+			}
+			// Extract fallback src="..."
+			if (preg_match('#\bsrc\s*=\s*([\"\'])(.*?)\1#i', $img_tag, $m)) {
+				$candidates[] = ['path' => $m[2], 'size' => ''];
+			}
+			foreach ($candidates as $entry) {
+				foreach ($this->valid_mimetypes as $mimetype) {
+					$formatted = $this->get_formatted_source($entry, $mimetype);
+					if ($formatted) {
+						$srcset = trim($formatted['src'] . ' ' . $formatted['size']);
+						$new_sources[] = '<source srcset="' . $srcset . '" type="' . $formatted['type'] . '" />';
+						break;
+					}
+				}
+			}
+		}
+		if (empty($new_sources)) {
+			return $this->raw_html;
+		}
+
+		$insertion = implode('', $new_sources);
+
+		// Insert newly built <source> elements immediately before the first <img>
+		return preg_replace('#(<img\b)#i', $insertion . '$1', $this->raw_html, 1);
+	}
+}
+
+class Tiny_Image_Source extends Tiny_Source_Base
+{
 	/**
 	 * Retrieves the image sources from the img element
 	 *
 	 * @return array{path: string, size: string}[] The image sources
 	 */
-	private function get_image_srcsets() {
+	private function get_image_srcsets()
+	{
 		$result = array();
-		$srcset = $this::get_attribute_value( $this->image, 'srcset' );
+		$srcset = $this::get_attribute_value($this->raw_html, 'srcset');
 
-		if ( $srcset ) {
+		if ($srcset) {
 			// Split the srcset to get individual entries
-			$srcset_entries = explode( ',', $srcset );
+			$srcset_entries = explode(',', $srcset);
 
-			foreach ( $srcset_entries as $entry ) {
+			foreach ($srcset_entries as $entry) {
 				// Trim whitespace
-				$entry = trim( $entry );
+				$entry = trim($entry);
 
 				// Split by whitespace to separate path and size descriptor
-				$parts = preg_split( '/\s+/', $entry, 2 );
+				$parts = preg_split('/\s+/', $entry, 2);
 
-				if ( count( $parts ) === 2 ) {
+				if (count($parts) === 2) {
 					// We have both path and size
 					$result[] = array(
 						'path' => $parts[0],
 						'size' => $parts[1],
 					);
-				} elseif ( count( $parts ) === 1 ) {
+				} elseif (count($parts) === 1) {
 					// We only have a path (unusual in srcset)
 					$result[] = array(
 						'path' => $parts[0],
@@ -242,8 +416,8 @@ class Tiny_Image_Source {
 			}
 		}
 
-		$source = $this::get_attribute_value( $this->image, 'src' );
-		if ( ! empty( $source ) ) {
+		$source = $this::get_attribute_value($this->raw_html, 'src');
+		if (! empty($source)) {
 			// No srcset, but we have a src attribute
 			$result[] = array(
 				'path' => $source,
@@ -253,27 +427,6 @@ class Tiny_Image_Source {
 		return $result;
 	}
 
-	private function get_local_path( $url ) {
-		if ( strpos( $url, 'http' ) === 0 ) {
-			$matched_domain = null;
-
-			foreach ( $this->allowed_domains as $domain ) {
-				if ( strpos( $url, $domain ) === 0 ) {
-					$matched_domain = $domain;
-					break;
-				}
-			}
-
-			if ( null === $matched_domain ) {
-				return '';
-			}
-
-			$url = substr( $url, strlen( $matched_domain ) );
-		}
-		$url = $this->base_dir . $url;
-
-		return $url;
-	}
 
 	/**
 	 * Generates a formatted image source array if the corresponding local file exists.
@@ -289,52 +442,36 @@ class Tiny_Image_Source {
 	 * @return array|null An array with 'srcset' and 'type' if the file exists locally,
 	 * 					  or null otherwise.
 	 */
-	private function get_formatted_source( $imgsrc, $mimetype ) {
-		$format_url = Tiny_Helpers::replace_file_extension( $mimetype, $imgsrc['path'] );
-		$local_path = $this->get_local_path( $format_url );
-		if ( empty( $local_path ) ) {
-			return null;
-		}
 
-		$exists_local = file_exists( $local_path );
-		if ( $exists_local ) {
-			return array(
-				'src' => $format_url,
-				'size' => $imgsrc['size'],
-				'type' => $mimetype,
-			);
-		}
-		return null;
-	}
-
-	public function create_picture_elements() {
+	public function create_picture_elements()
+	{
 		$srcsets = $this->get_image_srcsets();
 
 		$srcset_parts = array();
-		foreach ( $srcsets as $srcset ) {
-			foreach ( $this->valid_mimetypes as $mimetype ) {
-				$new_srcset = $this->get_formatted_source( $srcset, $mimetype );
+		foreach ($srcsets as $srcset) {
+			foreach ($this->valid_mimetypes as $mimetype) {
+				$new_srcset = $this->get_formatted_source($srcset, $mimetype);
 
-				if ( $new_srcset ) {
+				if ($new_srcset) {
 					$srcset_parts[] = $new_srcset;
 					break;
 				}
 			}
 		}
 
-		if ( empty( $srcset_parts ) ) {
-			return $this->image;
+		if (empty($srcset_parts)) {
+			return $this->raw_html;
 		}
 
-		$picture_element = array( '<picture>' );
-		foreach ( $srcset_parts as $source ) {
-			$srcset = trim( $source['src'] . ' ' . $source['size'] );
+		$picture_element = array('<picture>');
+		foreach ($srcset_parts as $source_part) {
+			$srcset = trim($source_part['src'] . ' ' . $source_part['size']);
 			$picture_element[] =
-				'<source srcset="' . $srcset . '" type="' . $source['type'] . '" />';
+				'<source srcset="' . $srcset . '" type="' . $source_part['type'] . '" />';
 		}
-		$picture_element[] = $this->image;
+		$picture_element[] = $this->raw_html;
 		$picture_element[] = '</picture>';
 
-		return implode( '', $picture_element );
+		return implode('', $picture_element);
 	}
 }

--- a/src/class-tiny-picture.php
+++ b/src/class-tiny-picture.php
@@ -379,7 +379,7 @@ abstract class Tiny_Source_Base {
 				}
 
 				$source_attr_parts['type'] = $mimetype;
-				$source_parts[] = '<source';
+				$source_parts = array( '<source' );
 				foreach ( $source_attr_parts as $source_attr_name => $source_attr_val ) {
 					$source_parts[] = $source_attr_name . '="' . $source_attr_val . '"';
 				}

--- a/test/integration/auth.setup.ts
+++ b/test/integration/auth.setup.ts
@@ -1,6 +1,5 @@
 import { test as setup } from '@playwright/test';
 import path from 'path';
-import { BASE_URL } from './utils';
 
 const authFile = path.join(__dirname, './.auth/user.json');
 
@@ -9,9 +8,11 @@ setup.describe('setup', () => {
     await page.goto('/wp-login.php');
     await page.fill('#user_login', 'admin');
     await page.fill('#user_pass', 'password');
-    await page.getByRole('button', { name: 'Log In' }).click();
 
-    await page.waitForURL(`${BASE_URL}/wp-admin`);
+    await Promise.all([
+      page.waitForURL('**/wp-admin/**', { timeout: 15000 }),
+      page.getByRole('button', { name: 'Log In' }).click(),
+    ]);
 
     await page.context().storageState({ path: authFile });
   });

--- a/test/integration/auth.setup.ts
+++ b/test/integration/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from '@playwright/test';
 import path from 'path';
+import { BASE_URL } from './utils';
 
 const authFile = path.join(__dirname, './.auth/user.json');
 
@@ -8,8 +9,9 @@ setup.describe('setup', () => {
     await page.goto('/wp-login.php');
     await page.fill('#user_login', 'admin');
     await page.fill('#user_pass', 'password');
-
     await page.getByRole('button', { name: 'Log In' }).click();
+
+    await page.waitForURL(`${BASE_URL}/wp-admin`);
 
     await page.context().storageState({ path: authFile });
   });

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -191,6 +191,28 @@ class Tiny_Picture_Test extends Tiny_TestCase
         $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
+    }
 
+    public function test_adds_both_avif_and_webp()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test.webp');
+        $this->wp->createImage(1000, '2025/01', 'test.avif');
+
+        $input = '<img src="/wp-content/uploads/2025/01/test.png">';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><source srcset="/wp-content/uploads/2025/01/test.avif" type="image/avif" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_img_with_query_and_fragment_keeps_both()
+    {
+        $this->wp->createImage(37857, '2025/09', 'test.avif');
+
+        $input = '<img src="/wp-content/uploads/2025/09/test.png?v=123#top">';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/09/test.avif" type="image/avif" /><img src="/wp-content/uploads/2025/09/test.png?v=123#top"></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
     }
 }

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -132,4 +132,54 @@ class Tiny_Picture_Test extends Tiny_TestCase
 
         $this->assertEquals($expected, $output);
     }
+
+    public function test_img_in_picture_element_ordered_attributes()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test.webp');
+        $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
+
+        $input = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_img_in_picture_element_srcset_sizes()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test.webp');
+        $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
+
+        $input = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_img_with_srcsets()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test-640w.webp');
+        $this->wp->createImage(1000, '2025/01', 'test-480w.webp');
+        $this->wp->createImage(1000, '2025/01', 'test-320w.webp');
+
+        $input = '<img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" />';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test-320w.webp, /wp-content/uploads/2025/01/test-480w.webp 1.5x, /wp-content/uploads/2025/01/test-640w.webp 2x, /wp-content/uploads/2025/01/test-640w.webp" type="image/webp" /><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" /></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_picture_with_srcsets()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test-640w.webp');
+        $this->wp->createImage(1000, '2025/01', 'test-480w.webp');
+        $this->wp->createImage(1000, '2025/01', 'test-320w.webp');
+
+        $input = '<picture><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" />';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test-320w.webp, /wp-content/uploads/2025/01/test-480w.webp 1.5x, /wp-content/uploads/2025/01/test-640w.webp 2x, /wp-content/uploads/2025/01/test-640w.webp" type="image/webp" /><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" /></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
 }

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -25,7 +25,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
     {
         $this->wp->createImage(37857, '2025/01', 'test.webp');
 
-        $output = $this->tiny_picture->replace_img_sources('<img src="https://www.tinifytest.com/wp-content/uploads/2025/01/test.png">');
+        $output = $this->tiny_picture->replace_sources('<img src="https://www.tinifytest.com/wp-content/uploads/2025/01/test.png">');
         $expected_output = '<picture><source srcset="https://www.tinifytest.com/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="https://www.tinifytest.com/wp-content/uploads/2025/01/test.png"></picture>';
         $this->assertEquals($expected_output, $output);
     }
@@ -36,7 +36,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
      */
     public function test_absolute_url_to_remote_image()
     {
-        $output = $this->tiny_picture->replace_img_sources('<img src="https://www.remotetinify.com/wp-content/uploads/2025/01/test.png">');
+        $output = $this->tiny_picture->replace_sources('<img src="https://www.remotetinify.com/wp-content/uploads/2025/01/test.png">');
         $expected_output = '<img src="https://www.remotetinify.com/wp-content/uploads/2025/01/test.png">';
         $this->assertEquals($expected_output, $output);
     }
@@ -48,7 +48,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
     {
         $this->wp->createImage(37857, '2025/01', 'test.webp');
 
-        $output = $this->tiny_picture->replace_img_sources('<img src="/wp-content/uploads/2025/01/test.png">');
+        $output = $this->tiny_picture->replace_sources('<img src="/wp-content/uploads/2025/01/test.png">');
         $expected_output = '<picture><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
         $this->assertEquals($expected_output, $output);
     }
@@ -59,7 +59,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
      */
     public function test_img_with_no_alternate_format_should_not_change()
     {
-        $output = $this->tiny_picture->replace_img_sources('<img src="/wp-content/uploads/2025/01/missing.png">');
+        $output = $this->tiny_picture->replace_sources('<img src="/wp-content/uploads/2025/01/missing.png">');
         $expected_output = '<img src="/wp-content/uploads/2025/01/missing.png">';
         $this->assertEquals($expected_output, $output);
     }
@@ -73,7 +73,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
     {
         $this->wp->createImage(37857, '2025/01', 'test.avif');
 
-        $output = $this->tiny_picture->replace_img_sources('<img src="/wp-content/uploads/2025/01/test.png?ver=123">');
+        $output = $this->tiny_picture->replace_sources('<img src="/wp-content/uploads/2025/01/test.png?ver=123">');
         $expected_output = '<picture><source srcset="/wp-content/uploads/2025/01/test.avif" type="image/avif" /><img src="/wp-content/uploads/2025/01/test.png?ver=123"></picture>';
         $this->assertEquals($expected_output, $output);
     }
@@ -85,7 +85,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
 
         $input = '<img src="/wp-content/uploads/2025/01/first.png" /><p>Hello</p><img src="/wp-content/uploads/2025/01/second.png" />';
         $expected = '<picture><source srcset="/wp-content/uploads/2025/01/first.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/first.png" /></picture><p>Hello</p><picture><source srcset="/wp-content/uploads/2025/01/second.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/second.png" /></picture>';
-        $output = $this->tiny_picture->replace_img_sources($input);
+        $output = $this->tiny_picture->replace_sources($input);
         $this->assertEquals($expected, $output);
     }
 
@@ -95,7 +95,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
 
         $input = '<img src="/wp-content/uploads/2025/01/test.png" class="lazy" alt="Test" loading="lazy">';
         $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png" class="lazy" alt="Test" loading="lazy"></picture>';
-        $output = $this->tiny_picture->replace_img_sources($input);
+        $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
     }
@@ -106,7 +106,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
 
         $input = '<IMG SRC="/wp-content/uploads/2025/01/test.png">';
         $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><IMG SRC="/wp-content/uploads/2025/01/test.png"></picture>';
-        $output = $this->tiny_picture->replace_img_sources($input);
+        $output = $this->tiny_picture->replace_sources($input);
         $this->assertEquals($expected, $output);
     }
 
@@ -116,7 +116,19 @@ class Tiny_Picture_Test extends Tiny_TestCase
 
         $input = '<a href="/something"><img src="/wp-content/uploads/2025/01/test.png"></a>';
         $expected = '<a href="/something"><picture><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture></a>';
-        $output = $this->tiny_picture->replace_img_sources($input);
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_img_in_picture_element()
+    {
+        $this->wp->createImage(1000, '2025/01', 'test.webp');
+        $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
+
+        $input = '<picture><source media="(max-width: 767px)" srcset="/wp-content/uploads/2025/01/test_500x500.png" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source media="(max-width: 767px)" srcset="/wp-content/uploads/2025/01/test_500x500.png" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
     }

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -127,7 +127,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
         $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
 
         $input = '<picture><source media="(max-width: 767px)" srcset="/wp-content/uploads/2025/01/test_500x500.png" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
-        $expected = '<picture><source media="(max-width: 767px)" srcset="/wp-content/uploads/2025/01/test_500x500.png" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source media="(max-width: 767px)" srcset="/wp-content/uploads/2025/01/test_500x500.png" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" media="(max-width: 767px)" type="image/webp" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
         $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
@@ -139,7 +139,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
         $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
 
         $input = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
-        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" media="(max-width: 767px)" type="image/webp" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
         $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
@@ -151,7 +151,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
         $this->wp->createImage(1000, '2025/01', 'test_500x500.webp');
 
         $input = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
-        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" type="image/webp" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test_500x500.png" media="(max-width: 767px)" /><source srcset="/wp-content/uploads/2025/01/test_500x500.webp" media="(max-width: 767px)" type="image/webp" /><source srcset="/wp-content/uploads/2025/01/test.webp" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.png"></picture>';
         $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
@@ -176,10 +176,21 @@ class Tiny_Picture_Test extends Tiny_TestCase
         $this->wp->createImage(1000, '2025/01', 'test-480w.webp');
         $this->wp->createImage(1000, '2025/01', 'test-320w.webp');
 
-        $input = '<picture><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" />';
+        $input = '<picture><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" /></picture>';
         $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test-320w.webp, /wp-content/uploads/2025/01/test-480w.webp 1.5x, /wp-content/uploads/2025/01/test-640w.webp 2x, /wp-content/uploads/2025/01/test-640w.webp" type="image/webp" /><img srcset="/wp-content/uploads/2025/01/test-320w.jpg, /wp-content/uploads/2025/01/test-480w.jpg 1.5x, /wp-content/uploads/2025/01/test-640w.jpg 2x" src="/wp-content/uploads/2025/01/test-640w.jpg" /></picture>';
         $output = $this->tiny_picture->replace_sources($input);
 
         $this->assertEquals($expected, $output);
+    }
+
+    public function test_picture_with_attributes() {
+        $this->wp->createImage(1000, '2025/01', 'test-landscape.webp');
+
+        $input = '<picture><source srcset="/wp-content/uploads/2025/01/test-landscape.jpg" width="200" height="200" media="(width >= 600px)" /><img src="/wp-content/uploads/2025/01/test.jpg" /></picture>';
+        $expected = '<picture><source srcset="/wp-content/uploads/2025/01/test-landscape.jpg" width="200" height="200" media="(width >= 600px)" /><source srcset="/wp-content/uploads/2025/01/test-landscape.webp" media="(width >= 600px)" width="200" height="200" type="image/webp" /><img src="/wp-content/uploads/2025/01/test.jpg" /></picture>';
+        $output = $this->tiny_picture->replace_sources($input);
+
+        $this->assertEquals($expected, $output);
+
     }
 }


### PR DESCRIPTION
With the compression feature turned on, the plug-in will parse images on `template_redirect`. This parsed <img> elements from the body to replace them with a picture element. One overlooked scenario was <img> elements already wrapped by a <picture> element.

Additionally, it was not semantically correct to have multiple sources of one srcset in the picture element. This scenario is now covered as well.

**Changes**
- Added a unit test for the bug scenario
- Filtered out picture elements when searching for img tags.
- Improved documentation on various regexes as the regexes are getting quite complex
- Created two classes, one for handling <img> tags and one for <picture> elements. Shared functionality comes from the base class.

**Considerations**
- Why not use DOMDocument to parse the html?
_DOMDocument is quite robust, it is not support or turned on for all servers/php runtimes. Therefor it is unsure wether we can use it or not._
- Why not use an existing package to read DOM nodes or attributes?
_Adding a package should not be taken lightly. It can increase vulnerability and complexity. Parsing the page for elements is a relatively small feature and adding a package for this might not be worth it._