### PR TITLE
Migrate public to private metakey

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.6.0",
     "composer/installers": "~1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=5.3.0",
     "composer/installers": "~1.0"
   },
   "require-dev": {

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,9 @@ A: You can upgrade to a paid account by adding your *Payment details* on your [a
 A: When the conversion feature is enabled (to convert images to AVIF or WebP), each image will use double the number of credits: one for compression and one for format conversion.
 
 == Changelog ==
+= 3.7.0 =
+* chore: migrated meta key from `tiny_compress_images` to `_tiny_compress_images`
+
 = 3.6.14 =
 * fix: added check for valid path before deleting converted image
 * fix: use hook uninstall_plugin instead of uninstall.php to prevent dependency deletion

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -141,7 +141,7 @@ class Tiny_Image {
 
 	/**
 	 * Will retrieve compression meta data for the given post_id.
-	 * 
+	 *
 	 * As migrations on large libraries can take longer, we will fall back on
 	 * the legacy key on migrating. We can remove the LEGACY_META_KEY on 3.8.0.
 	 *

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -139,9 +139,30 @@ class Tiny_Image {
 		return $filenames;
 	}
 
+	/**
+	 * Will retrieve compression meta data for the given post_id.
+	 * 
+	 * As migrations on large libraries can take longer, we will fall back on
+	 * the legacy key on migrating. We can remove the LEGACY_META_KEY on 3.8.0.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @param int $post_id Attachment ID.
+	 * @return mixed The stored tiny metadata, or '' when none exists.
+	 */
+	public static function get_tiny_metadata( $post_id ) {
+		$tiny_metadata = get_post_meta( $post_id, Tiny_Config::META_KEY, true );
+
+		if ( empty( $tiny_metadata ) ) {
+			$tiny_metadata = get_post_meta( $post_id, Tiny_Config::LEGACY_META_KEY, true );
+		}
+
+		return $tiny_metadata;
+	}
+
 	private function parse_tiny_metadata( $tiny_metadata = null ) {
 		if ( is_null( $tiny_metadata ) ) {
-			$tiny_metadata = get_post_meta( $this->id, Tiny_Config::META_KEY, true );
+			$tiny_metadata = Tiny_Image::get_tiny_metadata( $this->id );
 		}
 		if ( $tiny_metadata ) {
 			foreach ( $tiny_metadata as $size => $meta ) {

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -162,7 +162,7 @@ class Tiny_Image {
 
 	private function parse_tiny_metadata( $tiny_metadata = null ) {
 		if ( is_null( $tiny_metadata ) ) {
-			$tiny_metadata = Tiny_Image::get_tiny_metadata( $this->id );
+			$tiny_metadata = self::get_tiny_metadata( $this->id );
 		}
 		if ( $tiny_metadata ) {
 			foreach ( $tiny_metadata as $size => $meta ) {

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -29,13 +29,15 @@
 class Tiny_Migrate {
 
 	/**
-	 * The target version for the database. Not the same as plug-in version.
-	 * This will be incremented on every new migration.
+	 * The current database schema version.
+	 *
+	 * Increment this integer by 1 each time a new migration is added.
+	 * This is independent of the plugin version.
 	 *
 	 * @since 3.7.0
-	 * @var string
+	 * @var int
 	 */
-	const DB_VERSION = '3.7.0';
+	const DB_VERSION = 1;
 
 	/**
 	 * WordPress option key used to track the applied database version.
@@ -57,13 +59,13 @@ class Tiny_Migrate {
 	 * @return void
 	 */
 	public static function run() {
-		$stored_version = get_option( self::DB_VERSION_OPTION, '0' );
+		$stored_version = (int) get_option( self::DB_VERSION_OPTION, 0 );
 
-		if ( version_compare( $stored_version, self::DB_VERSION, '>=' ) ) {
+		if ( $stored_version >= self::DB_VERSION ) {
 			return;
 		}
 
-		if ( version_compare( $stored_version, '3.7.0', '<' ) ) {
+		if ( $stored_version < 1 ) {
 			self::migrate_370();
 		}
 

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -47,6 +47,23 @@ class Tiny_Migrate {
 	const DB_VERSION_OPTION = 'tinypng_db_version';
 
 	/**
+	 * Returns an ordered map of migrations keyed by version number.
+	 *
+	 * Each entry maps a version integer to a callable that performs the
+	 * corresponding migration. Add new entries in ascending version order.
+	 * Increment `DB_VERSION` when adding a new migration.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return array<int, callable> Ordered map of version to migration callable.
+	 */
+	private static function migrations() {
+		return array(
+			1 => array( self::class, 'migrate_meta_key_to_private' ),
+		);
+	}
+
+	/**
 	 * Runs all pending migrations in version order.
 	 *
 	 * Compares the stored database version against each known migration
@@ -64,8 +81,10 @@ class Tiny_Migrate {
 			return;
 		}
 
-		if ( $stored_version < 1 && ! self::migrate_meta_key_to_private() ) {
-			return;
+		foreach ( self::migrations() as $version => $migration ) {
+			if ( $stored_version < $version && ! call_user_func( $migration ) ) {
+				return;
+			}
 		}
 
 		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -82,7 +82,11 @@ class Tiny_Migrate {
 		}
 
 		foreach ( self::migrations() as $version => $migration ) {
-			if ( $stored_version < $version && ! call_user_func( $migration ) ) {
+			if ( $stored_version >= $version ) {
+				continue;
+			}
+
+			if ( ! call_user_func( $migration ) ) {
 				return;
 			}
 		}
@@ -98,7 +102,7 @@ class Tiny_Migrate {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @return boolean
+	 * @return bool True on success or when there is nothing to migrate, false on DB error.
 	 */
 	private static function migrate_meta_key_to_private() {
 		global $wpdb;
@@ -113,11 +117,13 @@ class Tiny_Migrate {
 		);
 
 		if ( false === $result ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'Tinify: failed to migrate meta key. DB error: ' . $wpdb->last_error );
 			return false;
 		}
 
 		// A return value of 0 means there was nothing to migrate, which is valid
- 		// for fresh installs or databases that were already migrated.
-		return false !== $result;;
+		// for fresh installs or databases that were already migrated.
+		return false !== $result;
 	}
 }

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -85,12 +85,16 @@ class Tiny_Migrate {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->update(
+		$result = $wpdb->update(
 			$wpdb->postmeta,
 			array( 'meta_key' => '_tiny_compress_images' ),
 			array( 'meta_key' => 'tiny_compress_images' ),
 			array( '%s' ),
 			array( '%s' )
 		);
+
+		if ( false === $result ) {
+			return false;
+		}
 	}
 }

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -49,7 +49,7 @@ class Tiny_Migrate {
 	/**
 	 * When migration fails, will pause migration for an hour
 	 * when the key exists in memory
-	 * 
+	 *
 	 * @since 3.7.0
 	 * @var string
 	 */
@@ -99,7 +99,6 @@ class Tiny_Migrate {
 				// transient key to hold migrations exists so exit early
 				return;
 			}
-
 
 			if ( ! call_user_func( $migration ) ) {
 				set_transient( self::MIGRATION_BACKOFF_KEY, 1, HOUR_IN_SECONDS );

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -64,8 +64,8 @@ class Tiny_Migrate {
 			return;
 		}
 
-		if ( $stored_version < 1 ) {
-			self::migrate_meta_key_to_private();
+		if ( $stored_version < 1 && ! self::migrate_meta_key_to_private() ) {
+			return;
 		}
 
 		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -47,6 +47,15 @@ class Tiny_Migrate {
 	const DB_VERSION_OPTION = 'tinypng_db_version';
 
 	/**
+	 * When migration fails, will pause migration for an hour
+	 * when the key exists in memory
+	 * 
+	 * @since 3.7.0
+	 * @var string
+	 */
+	const MIGRATION_BACKOFF_KEY = 'tinypng_migration_backoff';
+
+	/**
 	 * Returns an ordered map of migrations keyed by version number.
 	 *
 	 * Each entry maps a version integer to a callable that performs the
@@ -86,7 +95,14 @@ class Tiny_Migrate {
 				continue;
 			}
 
+			if ( get_transient( self::MIGRATION_BACKOFF_KEY ) ) {
+				// transient key to hold migrations exists so exit early
+				return;
+			}
+
+
 			if ( ! call_user_func( $migration ) ) {
+				set_transient( self::MIGRATION_BACKOFF_KEY, 1, HOUR_IN_SECONDS );
 				return;
 			}
 		}

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -79,7 +79,7 @@ class Tiny_Migrate {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	private static function migrate_meta_key_to_private() {
 		global $wpdb;
@@ -96,5 +96,7 @@ class Tiny_Migrate {
 		if ( false === $result ) {
 			return false;
 		}
+
+		return true;
 	}
 }

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -22,7 +22,7 @@
  * Handles sequential database migrations for the TinyPNG plugin.
  *
  * Each migration method targets a specific version and is only executed
- * once per site, tracked via the `tinypng_db_version` option.
+ * once per site, tracked via the `DB_VERSION_OPTION` constant.
  *
  * @since 3.7.0
  */

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -32,7 +32,6 @@ class Tiny_Migrate {
 	 * The current database schema version.
 	 *
 	 * Increment this integer by 1 each time a new migration is added.
-	 * This is independent of the plugin version.
 	 *
 	 * @since 3.7.0
 	 * @var int
@@ -66,7 +65,7 @@ class Tiny_Migrate {
 		}
 
 		if ( $stored_version < 1 ) {
-			self::migrate_370();
+			self::migrate_meta_key_to_private();
 		}
 
 		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
@@ -82,7 +81,7 @@ class Tiny_Migrate {
 	 *
 	 * @return void
 	 */
-	private static function migrate_370() {
+	private static function migrate_meta_key_to_private() {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -1,0 +1,95 @@
+<?php
+/*
+* Tiny Compress Images - WordPress plugin.
+* Copyright (C) 2015-2026 Tinify B.V.
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc., 51
+* Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+/**
+ * Handles sequential database migrations for the TinyPNG plugin.
+ *
+ * Each migration method targets a specific version and is only executed
+ * once per site, tracked via the `tinypng_db_version` option.
+ *
+ * @since 3.7.0
+ */
+class Tiny_Migrate {
+
+	/**
+	 * The target version for the database. Not the same as plug-in version.
+	 * This will be incremented on every new migration.
+	 *
+	 * @since 3.7.0
+	 * @var string
+	 */
+	const DB_VERSION = '3.7.0';
+
+	/**
+	 * WordPress option key used to track the applied database version.
+	 *
+	 * @since 3.7.0
+	 * @var string
+	 */
+	const DB_VERSION_OPTION = 'tinypng_db_version';
+
+	/**
+	 * Runs all pending migrations in version order.
+	 *
+	 * Compares the stored database version against each known migration
+	 * and executes any that have not yet been applied. Updates the stored
+	 * version upon completion.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return void
+	 */
+	public static function run() {
+		$stored_version = get_option( self::DB_VERSION_OPTION, '0' );
+
+		if ( version_compare( $stored_version, self::DB_VERSION, '>=' ) ) {
+			return;
+		}
+
+		if ( version_compare( $stored_version, '3.7.0', '<' ) ) {
+			self::migrate_370();
+		}
+
+		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
+	}
+
+	/**
+	 * Migrates the tiny meta key from public to private.
+	 *
+	 * Renames all `tiny_compress_images` post meta entries to
+	 * `_tiny_compress_images`.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return void
+	 */
+	private static function migrate_370() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$wpdb->postmeta,
+			array( 'meta_key' => '_tiny_compress_images' ),
+			array( 'meta_key' => 'tiny_compress_images' ),
+			array( '%s' ),
+			array( '%s' )
+		);
+	}
+}

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -97,6 +97,8 @@ class Tiny_Migrate {
 			return false;
 		}
 
-		return true;
+		// A return value of 0 means there was nothing to migrate, which is valid
+ 		// for fresh installs or databases that were already migrated.
+		return false !== $result;;
 	}
 }

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -48,7 +48,7 @@ class Tiny_Migrate {
 
 	/**
 	 * When migration fails, will pause migration for an hour
-	 * when the key exists in memory
+	 * as long as the key exists in transient
 	 *
 	 * @since 3.7.0
 	 * @var string

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -137,6 +137,8 @@ class Tiny_Migrate {
 			return false;
 		}
 
+		wp_cache_flush();
+
 		// A return value of 0 means there was nothing to migrate, which is valid
 		// for fresh installs or databases that were already migrated.
 		return false !== $result;

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -139,7 +139,7 @@ class Tiny_Migrate {
 				return false;
 			}
 		} while ( $batch_size === (int) $result );
-		
+
 		wp_cache_flush();
 
 		return true;

--- a/src/class-tiny-migrate.php
+++ b/src/class-tiny-migrate.php
@@ -122,25 +122,26 @@ class Tiny_Migrate {
 	private static function migrate_meta_key_to_private() {
 		global $wpdb;
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $wpdb->update(
-			$wpdb->postmeta,
-			array( 'meta_key' => '_tiny_compress_images' ),
-			array( 'meta_key' => 'tiny_compress_images' ),
-			array( '%s' ),
-			array( '%s' )
-		);
+		$batch_size = 2500;
+		do {
+			$query =
+				"UPDATE $wpdb->postmeta
+				SET meta_key = '_tiny_compress_images'
+				WHERE meta_key = 'tiny_compress_images'
+				LIMIT " . $batch_size;
 
-		if ( false === $result ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'Tinify: failed to migrate meta key. DB error: ' . $wpdb->last_error );
-			return false;
-		}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Renames a fixed internal meta key in fixed-size batches; only internal constants are interpolated.
+			$result = $wpdb->query( $query );
 
+			if ( false === $result ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Tinify: failed to migrate meta key. DB error: ' . $wpdb->last_error );
+				return false;
+			}
+		} while ( $batch_size === (int) $result );
+		
 		wp_cache_flush();
 
-		// A return value of 0 means there was nothing to migrate, which is valid
-		// for fresh installs or databases that were already migrated.
-		return false !== $result;
+		return true;
 	}
 }

--- a/src/config/class-tiny-config.php
+++ b/src/config/class-tiny-config.php
@@ -9,5 +9,5 @@ class Tiny_Config {
 	const SHRINK_URL                = 'https://api.tinify.com/shrink';
 	const KEYS_URL                  = 'https://api.tinify.com/keys';
 	const MONTHLY_FREE_COMPRESSIONS = 500;
-	const META_KEY                  = 'tiny_compress_images';
+	const META_KEY                  = '_tiny_compress_images';
 }

--- a/src/config/class-tiny-config.php
+++ b/src/config/class-tiny-config.php
@@ -10,4 +10,5 @@ class Tiny_Config {
 	const KEYS_URL                  = 'https://api.tinify.com/keys';
 	const MONTHLY_FREE_COMPRESSIONS = 500;
 	const META_KEY                  = '_tiny_compress_images';
+	const LEGACY_META_KEY           = 'tiny_compress_images';
 }

--- a/test/fixtures/class-tiny-config.php
+++ b/test/fixtures/class-tiny-config.php
@@ -1,17 +1,18 @@
 <?php
 
-if (! defined('TINY_DEBUG')) {
-	define('TINY_DEBUG', null);
+if ( ! defined( 'TINY_DEBUG' ) ) {
+	define( 'TINY_DEBUG', null );
 }
 
-class Tiny_Config
-{
+class Tiny_Config {
 	/* URL is only used by fopen driver. */
-	const SHRINK_URL = 'http://tinify-mock-api/shrink';
-	const KEYS_URL = 'http://tinify-mock-api/keys';
+	const SHRINK_URL                = 'http://tinify-mock-api/shrink';
+	const KEYS_URL                  = 'http://tinify-mock-api/keys';
 	const MONTHLY_FREE_COMPRESSIONS = 500;
-	const META_KEY = 'tiny_compress_images';
+	const META_KEY                  = '_tiny_compress_images';
+	const LEGACY_META_KEY           = 'tiny_compress_images';
 }
+
 
 // ajax hook to delete all attachments as doing it via UI is flaky
 add_action( 'wp_ajax_clear_media_library', 'clear_media_library' );

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -56,6 +56,7 @@ class WordPressStubs
 	private $calls;
 	private $stubs;
 	private $filters;
+	public $postmeta = 'wp_postmeta';
 
 	public function __construct($vfs)
 	{
@@ -98,6 +99,7 @@ class WordPressStubs
 		$this->addMethod('get_locale');
 		$this->addMethod('wp_timezone_string');
 		$this->addMethod('update_option');
+		$this->addMethod('update');
 		$this->addMethod('check_ajax_referer');
 		$this->addMethod('wp_json_encode');
 		$this->addMethod('wp_send_json_error');
@@ -144,7 +146,10 @@ class WordPressStubs
 		}
 		// Allow explicit stubs to override defaults/behaviors
 		if (isset($this->stubs[$method]) && $this->stubs[$method]) {
-			return call_user_func_array($this->stubs[$method], $args);
+			if (is_callable($this->stubs[$method])) {
+				return call_user_func_array($this->stubs[$method], $args);
+			}
+			return $this->stubs[$method];
 		}
 		if ('add_filter' === $method) {
 			$tag = isset($args[0]) ? $args[0] : '';

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -2,6 +2,7 @@
 
 define('ABSPATH', dirname(__FILE__) . '/../');
 define('WPINC', 'wp-includes-for-tests');
+define('HOUR_IN_SECONDS', 3600);
 require_once dirname(__FILE__) . '/../' . WPINC . '/file.php';
 
 use org\bovigo\vfs\vfsStream;
@@ -53,10 +54,12 @@ class WordPressStubs
 	private $admin_initFunctions;
 	private $options;
 	private $metadata;
+	private $transients;
 	private $calls;
 	private $stubs;
 	private $filters;
 	public $postmeta = 'wp_postmeta';
+	public $last_error = '';
 
 	public function __construct($vfs)
 	{
@@ -100,6 +103,9 @@ class WordPressStubs
 		$this->addMethod('wp_timezone_string');
 		$this->addMethod('update_option');
 		$this->addMethod('update');
+		$this->addMethod('get_transient');
+		$this->addMethod('set_transient');
+		$this->addMethod('delete_transient');
 		$this->addMethod('check_ajax_referer');
 		$this->addMethod('wp_json_encode');
 		$this->addMethod('wp_send_json_error');
@@ -124,6 +130,7 @@ class WordPressStubs
 		$this->admin_initFunctions = array();
 		$this->options = new WordPressOptions();
 		$this->metadata = array();
+		$this->transients = array();
 		$this->filters = array();
 		$GLOBALS['_wp_additional_image_sizes'] = array();
 	}
@@ -190,6 +197,18 @@ class WordPressStubs
 		}
 		if ('translate' === $method) {
 			return $args[0];
+	} elseif ('get_transient' === $method) {
+			$key = isset($args[0]) ? $args[0] : '';
+			return isset($this->transients[$key]) ? $this->transients[$key] : false;
+		} elseif ('set_transient' === $method) {
+			$key = isset($args[0]) ? $args[0] : '';
+			$value = isset($args[1]) ? $args[1] : '';
+			$this->transients[$key] = $value;
+			return true;
+		} elseif ('delete_transient' === $method) {
+			$key = isset($args[0]) ? $args[0] : '';
+			unset($this->transients[$key]);
+			return true;
 		} elseif ('get_option' === $method) {
 			return call_user_func_array(array($this->options, 'get'), $args);
 		} elseif ('get_post_meta' === $method) {
@@ -227,6 +246,11 @@ class WordPressStubs
 	public function addOption($key, $value)
 	{
 		$this->options->set($key, $value);
+	}
+
+	public function addTransient($key, $value)
+	{
+		$this->transients[$key] = $value;
 	}
 
 	public function addImageSize($size, $values)

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -153,10 +153,7 @@ class WordPressStubs
 		}
 		// Allow explicit stubs to override defaults/behaviors
 		if (isset($this->stubs[$method]) && $this->stubs[$method]) {
-			if (is_callable($this->stubs[$method])) {
-				return call_user_func_array($this->stubs[$method], $args);
-			}
-			return $this->stubs[$method];
+			return call_user_func_array($this->stubs[$method], $args);
 		}
 		if ('add_filter' === $method) {
 			$tag = isset($args[0]) ? $args[0] : '';

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -2,7 +2,9 @@
 
 define('ABSPATH', dirname(__FILE__) . '/../');
 define('WPINC', 'wp-includes-for-tests');
-define('HOUR_IN_SECONDS', 3600);
+if (! defined('HOUR_IN_SECONDS')) {
+	define('HOUR_IN_SECONDS', 3600);
+}
 require_once dirname(__FILE__) . '/../' . WPINC . '/file.php';
 
 use org\bovigo\vfs\vfsStream;

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -103,6 +103,8 @@ class WordPressStubs
 		$this->addMethod('wp_timezone_string');
 		$this->addMethod('update_option');
 		$this->addMethod('update');
+		$this->addMethod('query');
+		$this->addMethod('wp_cache_flush');
 		$this->addMethod('get_transient');
 		$this->addMethod('set_transient');
 		$this->addMethod('delete_transient');

--- a/test/unit/TinyImageTest.php
+++ b/test/unit/TinyImageTest.php
@@ -17,7 +17,7 @@ class Tiny_Image_Test extends Tiny_TestCase {
 	}
 
 	public function test_tiny_post_meta_key_may_never_change() {
-		$this->assertEquals( '61b16225f107e6f0a836bf19d47aa0fd912f8925', sha1( Tiny_Config::META_KEY ) );
+		$this->assertEquals( '438fc52ce17b9aedf0cf70dea52d5551affba59a', sha1( Tiny_Config::META_KEY ) );
 	}
 
 	public function test_update_wp_metadata_should_not_update_with_no_resized_original() {

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+require_once dirname(__FILE__) . '/TinyTestCase.php';
+require_once dirname(__FILE__) . '/../../src/class-tiny-migrate.php';
+
+class Tiny_Migrate_Test extends Tiny_TestCase
+{
+
+	public function set_up()
+	{
+		parent::set_up();
+		$this->wp->postmeta = 'wp_postmeta';
+		$this->wp->stub('update', 1);
+	}
+
+	/**
+	 * Helper to check if a specific option update occurred.
+	 */
+	private function assertOptionWasUpdated($option, $value)
+	{
+		$calls = $this->wp->getCalls('update_option');
+		foreach ($calls as $call) {
+			if (($call[0] ?? null) === $option && ($call[1] ?? null) === $value) {
+				return $this->assertTrue(true);
+			}
+		}
+		$this->fail("Failed asserting that option '$option' was updated to '$value'.");
+	}
+
+	public function test_run_skips_migration_when_db_version_is_current()
+	{
+		$this->wp->addOption(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
+
+		Tiny_Migrate::run();
+
+		$this->assertCount(0, $this->wp->getCalls('update'), 'Should not touch DB if version matches.');
+	}
+
+	public function test_run_performs_migration_and_updates_version()
+	{
+		Tiny_Migrate::run();
+
+		$update_calls = $this->wp->getCalls('update');
+		$this->assertCount(1, $update_calls);
+
+		list($table, $data, $where) = $update_calls[0];
+
+		$this->assertEquals('wp_postmeta', $table);
+		$this->assertEquals(['meta_key' => '_tiny_compress_images'], $data);
+		$this->assertEquals(['meta_key' => 'tiny_compress_images'], $where);
+
+		$this->assertOptionWasUpdated(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
+	}
+
+	public function test_run_does_not_update_option_if_unnecessary()
+	{
+		$this->wp->addOption(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
+
+		Tiny_Migrate::run();
+
+		$option_calls = $this->wp->getCalls('update_option');
+		$version_updates = array_filter($option_calls, fn($call) => $call[0] === Tiny_Migrate::DB_VERSION_OPTION);
+
+		$this->assertEmpty($version_updates, 'Should not re-save the version if already current.');
+	}
+}

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -51,6 +51,18 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		$this->assertOptionWasUpdated(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
 	}
 
+	public function test_run_does_not_update_db_version_when_migration_fails()
+	{
+		$this->wp->stub('update', function() { return false; });
+
+		Tiny_Migrate::run();
+
+		$option_calls = $this->wp->getCalls('update_option');
+		$version_updates = array_filter($option_calls, fn($call) => $call[0] === Tiny_Migrate::DB_VERSION_OPTION);
+
+		$this->assertEmpty($version_updates, 'Should not update DB version when migration fails.');
+	}
+
 	public function test_run_does_not_update_option_if_unnecessary()
 	{
 		$this->wp->addOption(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -9,7 +9,6 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 	public function set_up()
 	{
 		parent::set_up();
-		$this->wp->postmeta = 'wp_postmeta';
 		$this->wp->stub('update', 1);
 	}
 

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -19,7 +19,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 	{
 		$calls = $this->wp->getCalls('update_option');
 		foreach ($calls as $call) {
-			if (($call[0] ?? null) === $option && ($call[1] ?? null) === $value) {
+			if (isset($call[0], $call[1]) && $call[0] === $option && $call[1] === $value) {
 				return $this->assertTrue(true);
 			}
 		}
@@ -45,8 +45,8 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		list($table, $data, $where) = $update_calls[0];
 
 		$this->assertEquals('wp_postmeta', $table);
-		$this->assertEquals(['meta_key' => '_tiny_compress_images'], $data);
-		$this->assertEquals(['meta_key' => 'tiny_compress_images'], $where);
+		$this->assertEquals(array('meta_key' => '_tiny_compress_images'), $data);
+		$this->assertEquals(array('meta_key' => 'tiny_compress_images'), $where);
 
 		$this->assertOptionWasUpdated(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
 	}
@@ -58,7 +58,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		Tiny_Migrate::run();
 
 		$option_calls = $this->wp->getCalls('update_option');
-		$version_updates = array_filter($option_calls, fn($call) => $call[0] === Tiny_Migrate::DB_VERSION_OPTION);
+		$version_updates = array_filter($option_calls, function($call) { return $call[0] === Tiny_Migrate::DB_VERSION_OPTION; });
 
 		$this->assertEmpty($version_updates, 'Should not update DB version when migration fails.');
 	}
@@ -70,7 +70,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		Tiny_Migrate::run();
 
 		$option_calls = $this->wp->getCalls('update_option');
-		$version_updates = array_filter($option_calls, fn($call) => $call[0] === Tiny_Migrate::DB_VERSION_OPTION);
+		$version_updates = array_filter($option_calls, function($call) { return $call[0] === Tiny_Migrate::DB_VERSION_OPTION; });
 
 		$this->assertEmpty($version_updates, 'Should not re-save the version if already current.');
 	}

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -74,4 +74,27 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 
 		$this->assertEmpty($version_updates, 'Should not re-save the version if already current.');
 	}
+
+	public function test_run_sets_backoff_transient_when_migration_fails()
+	{
+		$this->wp->stub('update', function() { return false; });
+
+		Tiny_Migrate::run();
+
+		$set_transient_calls = $this->wp->getCalls('set_transient');
+		$this->assertCount(1, $set_transient_calls, 'A backoff transient should be set after a failed migration.');
+		$this->assertEquals(Tiny_Migrate::MIGRATION_BACKOFF_KEY, $set_transient_calls[0][0]);
+		$this->assertEquals(HOUR_IN_SECONDS, $set_transient_calls[0][2]);
+	}
+
+	public function test_run_skips_migration_when_backoff_transient_is_set()
+	{
+		$this->wp->stub('get_transient', function($key) {
+			return Tiny_Migrate::MIGRATION_BACKOFF_KEY === $key ? 1 : false;
+		});
+
+		Tiny_Migrate::run();
+
+		$this->assertCount(0, $this->wp->getCalls('update'), 'DB update should not be attempted during the backoff period.');
+	}
 }

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -9,7 +9,11 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 	public function set_up()
 	{
 		parent::set_up();
-		$this->wp->stub('update', 1);
+		// migration test logs error in stdout so swallow error logs
+		ini_set('error_log', '/dev/null');
+		$this->wp->stub('update', function() {
+			return 1;
+		});
 	}
 
 	/**
@@ -69,10 +73,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 
 		Tiny_Migrate::run();
 
-		$option_calls = $this->wp->getCalls('update_option');
-		$version_updates = array_filter($option_calls, function($call) { return $call[0] === Tiny_Migrate::DB_VERSION_OPTION; });
-
-		$this->assertEmpty($version_updates, 'Should not re-save the version if already current.');
+		$this->assertEmpty($this->wp->getCalls('update_option'), 'Should not call update_option at all when version is already current.');
 	}
 
 	public function test_run_sets_backoff_transient_when_migration_fails()

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -9,8 +9,6 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 	public function set_up()
 	{
 		parent::set_up();
-		// migration test logs error in stdout so swallow error logs
-		ini_set('error_log', '/dev/null');
 		$this->wp->stub('query', function() {
 			return 1;
 		});

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -83,7 +83,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 	{
 		$this->wp->updateMetadata(1, Tiny_Config::META_KEY, array('size' => 'current'));
 
-		$this->assertEquals(array('size' => 'current'), Tiny_Migrate::get_tiny_metadata(1));
+		$this->assertEquals(array('size' => 'current'), Tiny_Image::get_tiny_metadata(1));
 	}
 
 	public function test_get_tiny_metadata_falls_back_to_legacy_key_before_migration()
@@ -92,7 +92,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		// not run yet (or is still in flight / backed off).
 		$this->wp->updateMetadata(1, Tiny_Config::LEGACY_META_KEY, array('size' => 'legacy'));
 
-		$this->assertEquals(array('size' => 'legacy'), Tiny_Migrate::get_tiny_metadata(1));
+		$this->assertEquals(array('size' => 'legacy'), Tiny_Image::get_tiny_metadata(1));
 	}
 
 	public function test_get_tiny_metadata_prefers_current_key_over_legacy()
@@ -100,12 +100,12 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		$this->wp->updateMetadata(1, Tiny_Config::LEGACY_META_KEY, array('size' => 'legacy'));
 		$this->wp->updateMetadata(1, Tiny_Config::META_KEY, array('size' => 'current'));
 
-		$this->assertEquals(array('size' => 'current'), Tiny_Migrate::get_tiny_metadata(1));
+		$this->assertEquals(array('size' => 'current'), Tiny_Image::get_tiny_metadata(1));
 	}
 
 	public function test_get_tiny_metadata_returns_empty_when_no_metadata_exists()
 	{
-		$this->assertEmpty(Tiny_Migrate::get_tiny_metadata(1));
+		$this->assertEmpty(Tiny_Image::get_tiny_metadata(1));
 	}
 
 	public function test_run_flushes_object_cache_after_migrating()

--- a/test/unit/TinyMigrateTest.php
+++ b/test/unit/TinyMigrateTest.php
@@ -11,8 +11,22 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 		parent::set_up();
 		// migration test logs error in stdout so swallow error logs
 		ini_set('error_log', '/dev/null');
-		$this->wp->stub('update', function() {
+		$this->wp->stub('query', function() {
 			return 1;
+		});
+	}
+
+	/**
+	 * Stubs $wpdb->query to return the given row counts on successive calls,
+	 * simulating the batched UPDATE draining the table.
+	 */
+	private function queueQueryResults(array $results)
+	{
+		$index = 0;
+		$this->wp->stub('query', function() use (&$index, $results) {
+			$value = isset($results[$index]) ? $results[$index] : 0;
+			$index++;
+			return $value;
 		});
 	}
 
@@ -36,28 +50,85 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 
 		Tiny_Migrate::run();
 
-		$this->assertCount(0, $this->wp->getCalls('update'), 'Should not touch DB if version matches.');
+		$this->assertCount(0, $this->wp->getCalls('query'), 'Should not touch DB if version matches.');
 	}
 
 	public function test_run_performs_migration_and_updates_version()
 	{
 		Tiny_Migrate::run();
 
-		$update_calls = $this->wp->getCalls('update');
-		$this->assertCount(1, $update_calls);
+		$query_calls = $this->wp->getCalls('query');
+		$this->assertCount(1, $query_calls);
 
-		list($table, $data, $where) = $update_calls[0];
+		$sql = $query_calls[0][0];
 
-		$this->assertEquals('wp_postmeta', $table);
-		$this->assertEquals(array('meta_key' => '_tiny_compress_images'), $data);
-		$this->assertEquals(array('meta_key' => 'tiny_compress_images'), $where);
+		$this->assertStringContainsString('UPDATE wp_postmeta', $sql);
+		$this->assertStringContainsString("SET meta_key = '_tiny_compress_images'", $sql);
+		$this->assertStringContainsString("WHERE meta_key = 'tiny_compress_images'", $sql);
+		$this->assertStringContainsString('LIMIT ' . 2500, $sql);
 
 		$this->assertOptionWasUpdated(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
 	}
 
+	public function test_run_renames_meta_key_in_batches()
+	{
+		// Two full batches (2500 rows) followed by a partial batch end the loop.
+		$this->queueQueryResults(array(2500, 2500, 42));
+
+		Tiny_Migrate::run();
+
+		$this->assertCount(3, $this->wp->getCalls('query'), 'Should keep batching until a partial batch is returned.');
+		$this->assertOptionWasUpdated(Tiny_Migrate::DB_VERSION_OPTION, Tiny_Migrate::DB_VERSION);
+	}
+
+	public function test_get_tiny_metadata_reads_the_current_private_key()
+	{
+		$this->wp->updateMetadata(1, Tiny_Config::META_KEY, array('size' => 'current'));
+
+		$this->assertEquals(array('size' => 'current'), Tiny_Migrate::get_tiny_metadata(1));
+	}
+
+	public function test_get_tiny_metadata_falls_back_to_legacy_key_before_migration()
+	{
+		// Data still lives under the old public key because the migration has
+		// not run yet (or is still in flight / backed off).
+		$this->wp->updateMetadata(1, Tiny_Config::LEGACY_META_KEY, array('size' => 'legacy'));
+
+		$this->assertEquals(array('size' => 'legacy'), Tiny_Migrate::get_tiny_metadata(1));
+	}
+
+	public function test_get_tiny_metadata_prefers_current_key_over_legacy()
+	{
+		$this->wp->updateMetadata(1, Tiny_Config::LEGACY_META_KEY, array('size' => 'legacy'));
+		$this->wp->updateMetadata(1, Tiny_Config::META_KEY, array('size' => 'current'));
+
+		$this->assertEquals(array('size' => 'current'), Tiny_Migrate::get_tiny_metadata(1));
+	}
+
+	public function test_get_tiny_metadata_returns_empty_when_no_metadata_exists()
+	{
+		$this->assertEmpty(Tiny_Migrate::get_tiny_metadata(1));
+	}
+
+	public function test_run_flushes_object_cache_after_migrating()
+	{
+		Tiny_Migrate::run();
+
+		$this->assertCount(1, $this->wp->getCalls('wp_cache_flush'), 'Object cache must be flushed so reads see the renamed key.');
+	}
+
+	public function test_run_does_not_flush_cache_when_migration_fails()
+	{
+		$this->wp->stub('query', function() { return false; });
+
+		Tiny_Migrate::run();
+
+		$this->assertCount(0, $this->wp->getCalls('wp_cache_flush'));
+	}
+
 	public function test_run_does_not_update_db_version_when_migration_fails()
 	{
-		$this->wp->stub('update', function() { return false; });
+		$this->wp->stub('query', function() { return false; });
 
 		Tiny_Migrate::run();
 
@@ -78,7 +149,7 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 
 	public function test_run_sets_backoff_transient_when_migration_fails()
 	{
-		$this->wp->stub('update', function() { return false; });
+		$this->wp->stub('query', function() { return false; });
 
 		Tiny_Migrate::run();
 
@@ -96,6 +167,6 @@ class Tiny_Migrate_Test extends Tiny_TestCase
 
 		Tiny_Migrate::run();
 
-		$this->assertCount(0, $this->wp->getCalls('update'), 'DB update should not be attempted during the backoff period.');
+		$this->assertCount(0, $this->wp->getCalls('query'), 'DB update should not be attempted during the backoff period.');
 	}
 }

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -38,7 +38,7 @@ if ( Tiny_PHP::client_supported() ) {
 	require dirname( __FILE__ ) . '/src/class-tiny-compress-fopen.php';
 }
 
-Tiny_Migrate::run();
+add_action( 'plugins_loaded', array( 'Tiny_Migrate', 'run' ) );
 
 $tiny_plugin = new Tiny_Plugin();
 

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -10,6 +10,7 @@
  */
 
 require dirname( __FILE__ ) . '/src/config/class-tiny-config.php';
+require dirname( __FILE__ ) . '/src/class-tiny-migrate.php';
 require dirname( __FILE__ ) . '/src/class-tiny-helpers.php';
 require dirname( __FILE__ ) . '/src/class-tiny-php.php';
 require dirname( __FILE__ ) . '/src/class-tiny-wp-base.php';
@@ -36,6 +37,8 @@ if ( Tiny_PHP::client_supported() ) {
 } else {
 	require dirname( __FILE__ ) . '/src/class-tiny-compress-fopen.php';
 }
+
+Tiny_Migrate::run();
 
 $tiny_plugin = new Tiny_Plugin();
 

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -38,7 +38,7 @@ if ( Tiny_PHP::client_supported() ) {
 	require dirname( __FILE__ ) . '/src/class-tiny-compress-fopen.php';
 }
 
-add_action( 'plugins_loaded', array( 'Tiny_Migrate', 'run' ) );
+add_action( 'admin_init', array( 'Tiny_Migrate', 'run' ) );
 
 $tiny_plugin = new Tiny_Plugin();
 


### PR DESCRIPTION
Will migrate the `tiny_compress_images` to `_tiny_compress_images` marking it as a private key. This will ensure that the field will not be editable through custom fields.

**Changed**
- Added `Tiny_Migrate` class to contain migrations.
  - It has a method `run` which runs before the plugin does (see `tiny-compress-images.php`)
  - The method will compare a const DB_VERSION_NR to the stored version
    - If the stored version number is higher than the constant, it will exit and not run migrations.
    - If the stored version does not exist or is lower it will run down the path to check migrations
  - For standards, each migration:
    - will have a associated version number. 
    - is a private static in the migration class

**Considerations**
- Why a seperate version number for the database and not follow plugin versions? _It will be easier to follow on which version you are on. 1 -> 2 -> 3 is easier to follow than 3.7.0 -> 4.2.0 -> 5.6.0._
- When comparing to https://github.com/tinify/wordpress-plugin/pull/34, what are the differences? The other version uses a N+1 loop to do a separate db query which might end up with a ton of queries. PR 34 also does a update and then delete which is two queries. Straight update (https://developer.wordpress.org/reference/classes/wpdb/update/) is considerably more stable and reliable.  

After merging, we can close:
- https://github.com/tinify/wordpress-plugin/pull/34
- https://github.com/tinify/wordpress-plugin/issues/33