### PR TITLE
PCP Plugin Check

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,8 +2,24 @@
 <ruleset>
   <config name="testVersion" value="5.6-"/>
 
-  <rule ref="WordPress-Core">
-     <exclude name="Universal.Operators.StrictComparisons" />
+  <rule ref="WordPress">
+    <exclude name="Universal.Operators.StrictComparisons" />
+
+    <!-- Resolve commenting related violations -->
+    <exclude name="Squiz.Commenting" />
+    <exclude name="Generic.Commenting" />
+    <exclude name="Squiz.PHP.CommentedOutCode.Found" />
+
+    <!-- Fix security issues -->
+    <exclude name="WordPress.Security.EscapeOutput" />
+    <exclude name="WordPress.Security.ValidatedSanitizedInput" />
+    <exclude name="WordPress.Security.NonceVerification" />
+
+    <!-- Fix AlternativeFunctons-->
+    <exclude name="WordPress.WP.AlternativeFunctions" />
+    <exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
+    <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
+    <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />
   </rule>
   <rule ref="Generic.Files.LineLength">
     <properties>

--- a/src/class-tiny-apache-rewrite.php
+++ b/src/class-tiny-apache-rewrite.php
@@ -31,6 +31,7 @@ class Tiny_Apache_Rewrite extends Tiny_WP_Base {
 
 	/**
 	 * seperator when rules are inserted
+	 *
 	 * @var string
 	 */
 	const MARKER = 'tiny-compress-images';
@@ -40,9 +41,8 @@ class Tiny_Apache_Rewrite extends Tiny_WP_Base {
 	 * hooked into `update_option_tinypng_convert_format`
 	 * https://developer.wordpress.org/reference/hooks/update_option_option/
 	 *
-	 *
-	 * @param mixed $old_value
-	 * @param mixed $value
+	 * @param mixed  $old_value
+	 * @param mixed  $value
 	 * @param string $option
 	 * @return void
 	 */

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -42,7 +42,7 @@ class Tiny_Bulk_Optimization {
 				if ( isset( $last_image['ID'] ) ) {
 					$last_image_id = $last_image['ID'];
 				}
-			} while ( sizeof( $result ) == self::PAGING_SIZE );
+			} while ( count( $result ) == self::PAGING_SIZE );
 		} else {
 			$stats = self::populate_optimization_statistics( $settings, $result, $stats );
 		}
@@ -104,7 +104,7 @@ class Tiny_Bulk_Optimization {
 		$active_tinify_sizes = $settings->get_active_tinify_sizes();
 		$conversion_enabled  = $settings->get_conversion_enabled();
 
-		for ( $i = 0; $i < sizeof( $result ); $i++ ) {
+		for ( $i = 0; $i < count( $result ); $i++ ) {
 			$wp_metadata   = unserialize( (string) $result[ $i ]['meta_value'] );
 			$tiny_metadata = isset( $result[ $i ]['tiny_meta_value'] ) ?
 				unserialize( (string) $result[ $i ]['tiny_meta_value'] ) :

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -42,7 +42,8 @@ class Tiny_Bulk_Optimization {
 				if ( isset( $last_image['ID'] ) ) {
 					$last_image_id = $last_image['ID'];
 				}
-			} while ( count( $result ) == self::PAGING_SIZE );
+				$result_count = count( $result );
+			} while ( self::PAGING_SIZE == $result_count );
 		} else {
 			$stats = self::populate_optimization_statistics( $settings, $result, $stats );
 		}
@@ -104,7 +105,8 @@ class Tiny_Bulk_Optimization {
 		$active_tinify_sizes = $settings->get_active_tinify_sizes();
 		$conversion_enabled  = $settings->get_conversion_enabled();
 
-		for ( $i = 0; $i < count( $result ); $i++ ) {
+		$result_count = count( $result );
+		for ( $i = 0; $i < $result_count; $i++ ) {
 			$wp_metadata   = unserialize( (string) $result[ $i ]['meta_value'] );
 			$tiny_metadata = isset( $result[ $i ]['tiny_meta_value'] ) ?
 				unserialize( (string) $result[ $i ]['tiny_meta_value'] ) :

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -107,9 +107,9 @@ class Tiny_Bulk_Optimization {
 
 		$result_count = count( $result );
 		for ( $i = 0; $i < $result_count; $i++ ) {
-			$wp_metadata   = unserialize( (string) $result[ $i ]['meta_value'] );
+			$wp_metadata   = maybe_unserialize( (string) $result[ $i ]['meta_value'] );
 			$tiny_metadata = isset( $result[ $i ]['tiny_meta_value'] ) ?
-				unserialize( (string) $result[ $i ]['tiny_meta_value'] ) :
+				maybe_unserialize( (string) $result[ $i ]['tiny_meta_value'] ) :
 				array();
 			if ( ! is_array( $tiny_metadata ) ) {
 				$tiny_metadata = array();

--- a/src/class-tiny-cli.php
+++ b/src/class-tiny-cli.php
@@ -52,7 +52,6 @@ class Tiny_Cli {
 	 *      optimize all unprocessed images
 	 *      wp tiny optimize
 	 *
-	 *
 	 * @param array $args
 	 * @param array $assoc_args
 	 * @return void

--- a/src/class-tiny-compress-client.php
+++ b/src/class-tiny-compress-client.php
@@ -98,7 +98,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			}
 
 			throw new Tiny_Exception(
-				$err->getMessage(),
+				esc_html( $err->getMessage() ),
 				get_class( $err ),
 				$err->status
 			);
@@ -165,7 +165,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			);
 
 			throw new Tiny_Exception(
-				$err->getMessage(),
+				esc_html( $err->getMessage() ),
 				get_class( $err ),
 				$err->status
 			);
@@ -184,7 +184,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			$this->last_error_code = $err->status;
 
 			throw new Tiny_Exception(
-				$err->getMessage(),
+				esc_html( $err->getMessage() ),
 				get_class( $err ),
 				$err->status
 			);
@@ -192,7 +192,8 @@ class Tiny_Compress_Client extends Tiny_Compress {
 	}
 
 	private function set_request_options( $client ) {
-		/* The client does not let us override cURL properties yet, so we have
+		/*
+		The client does not let us override cURL properties yet, so we have
 			to use a reflection property. */
 		$property = new ReflectionProperty( $client, 'options' );
 		$property->setAccessible( true );

--- a/src/class-tiny-compress-client.php
+++ b/src/class-tiny-compress-client.php
@@ -98,7 +98,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			}
 
 			throw new Tiny_Exception(
-				esc_html( $err->getMessage() ),
+				$err->getMessage(),
 				get_class( $err ),
 				$err->status
 			);
@@ -165,7 +165,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			);
 
 			throw new Tiny_Exception(
-				esc_html( $err->getMessage() ),
+				$err->getMessage(),
 				get_class( $err ),
 				$err->status
 			);
@@ -184,7 +184,7 @@ class Tiny_Compress_Client extends Tiny_Compress {
 			$this->last_error_code = $err->status;
 
 			throw new Tiny_Exception(
-				esc_html( $err->getMessage() ),
+				$err->getMessage(),
 				get_class( $err ),
 				$err->status
 			);

--- a/src/class-tiny-compress-fopen.php
+++ b/src/class-tiny-compress-fopen.php
@@ -266,7 +266,7 @@ class Tiny_Compress_Fopen extends Tiny_Compress {
 				'header'          => array_merge(
 					$headers,
 					array(
-						'Authorization: Basic ' . base64_encode( 'api:' . $this->api_key ),
+						'Authorization: Basic ' . base64_encode( 'api:' . $this->api_key ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Base64 encoding is required.
 						'User-Agent: ' . self::identifier(),
 						'Content-Type: multipart/form-data',
 					)

--- a/src/class-tiny-compress.php
+++ b/src/class-tiny-compress.php
@@ -96,9 +96,9 @@ abstract class Tiny_Compress {
 	/**
 	 * Compresses a single file
 	 *
-	 * @param [type] $file
-	 * @param array $resize_opts
-	 * @param array $preserve_opts
+	 * @param [type]                             $file
+	 * @param array                              $resize_opts
+	 * @param array                              $preserve_opts
 	 * @param array{ string } conversion options
 	 * @return void
 	 */

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -29,7 +29,7 @@ class Tiny_Helpers {
 	 * We can use mb_strlen & mb_substr as WordPress provides a compat function for
 	 * it if mbstring php module is not installed.
 	 *
-	 * @param string $text the text
+	 * @param string  $text the text
 	 * @param integer $length the maximum length of the string
 	 * @return string the truncated string
 	 */
@@ -173,17 +173,17 @@ class Tiny_Helpers {
 	}
 
 	/**
-	* Polyfill for `str_starts_with()` function added in PHP 8.0.
-	*
-	* Performs a case-sensitive check indicating if
-	* the haystack begins with needle.
-	*
-	* @since 5.9.0
-	*
-	* @param string $haystack The string to search in.
-	* @param string $needle   The substring to search for in the `$haystack`.
-	* @return bool True if `$haystack` starts with `$needle`, otherwise false.
-	*/
+	 * Polyfill for `str_starts_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack begins with needle.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$haystack` starts with `$needle`, otherwise false.
+	 */
 	public static function str_starts_with( $haystack, $needle ) {
 		if ( function_exists( 'str_starts_with' ) ) {
 			return str_starts_with( $haystack, $needle );

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -132,7 +132,7 @@ class Tiny_Image_Size {
 	public function mimetype() {
 		if ( is_null( $this->mime_type ) ) {
 			if ( $this->exists() ) {
-				$file             = file_get_contents( $this->filename );
+				$file            = file_get_contents( $this->filename );
 				$this->mime_type = Tiny_Helpers::get_mimetype( $file );
 			} else {
 				$this->mime_type = 'application/octet-stream';

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -211,7 +211,7 @@ class Tiny_Image_Size {
 
 	public function uncompressed() {
 		return $this->exists() &&
-			! $this->isduplicate() &&
+			! $this->is_duplicate() &&
 			! ( isset( $this->meta['output'] ) && $this->same_size() );
 	}
 
@@ -227,12 +227,12 @@ class Tiny_Image_Size {
 		);
 	}
 
-	public function markduplicate( $duplicate_size_name ) {
+	public function mark_duplicate( $duplicate_size_name ) {
 		$this->duplicate         = true;
 		$this->duplicate_of_size = $duplicate_size_name;
 	}
 
-	public function isduplicate() {
+	public function is_duplicate() {
 		return $this->duplicate;
 	}
 

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -23,11 +23,11 @@ class Tiny_Image_Size {
 	public $meta = array();
 
 	/* Used more than once and not trivial, so we are memoizing these */
-	private $_exists;
-	private $_file_size;
-	private $_mime_type;
-	private $_duplicate         = false;
-	private $_duplicate_of_size = '';
+	private $exists;
+	private $file_size;
+	private $mime_type;
+	private $duplicate         = false;
+	private $duplicate_of_size = '';
 
 	public function __construct( $filename = null ) {
 		$this->filename = $filename;
@@ -119,33 +119,33 @@ class Tiny_Image_Size {
 	}
 
 	public function filesize() {
-		if ( is_null( $this->_file_size ) ) {
+		if ( is_null( $this->file_size ) ) {
 			if ( $this->exists() ) {
-				$this->_file_size = filesize( $this->filename );
+				$this->file_size = filesize( $this->filename );
 			} else {
-				$this->_file_size = 0;
+				$this->file_size = 0;
 			}
 		}
-		return $this->_file_size;
+		return $this->file_size;
 	}
 
 	public function mimetype() {
-		if ( is_null( $this->_mime_type ) ) {
+		if ( is_null( $this->mime_type ) ) {
 			if ( $this->exists() ) {
 				$file             = file_get_contents( $this->filename );
-				$this->_mime_type = Tiny_Helpers::get_mimetype( $file );
+				$this->mime_type = Tiny_Helpers::get_mimetype( $file );
 			} else {
-				$this->_mime_type = 'application/octet-stream';
+				$this->mime_type = 'application/octet-stream';
 			}
 		}
-		return $this->_mime_type;
+		return $this->mime_type;
 	}
 
 	public function exists() {
-		if ( is_null( $this->_exists ) ) {
-			$this->_exists = $this->filename && file_exists( $this->filename );
+		if ( is_null( $this->exists ) ) {
+			$this->exists = $this->filename && file_exists( $this->filename );
 		}
-		return $this->_exists;
+		return $this->exists;
 	}
 
 	private function same_size() {
@@ -211,7 +211,7 @@ class Tiny_Image_Size {
 
 	public function uncompressed() {
 		return $this->exists() &&
-			! $this->is_duplicate() &&
+			! $this->isduplicate() &&
 			! ( isset( $this->meta['output'] ) && $this->same_size() );
 	}
 
@@ -227,17 +227,17 @@ class Tiny_Image_Size {
 		);
 	}
 
-	public function mark_duplicate( $duplicate_size_name ) {
-		$this->_duplicate         = true;
-		$this->_duplicate_of_size = $duplicate_size_name;
+	public function markduplicate( $duplicate_size_name ) {
+		$this->duplicate         = true;
+		$this->duplicate_of_size = $duplicate_size_name;
 	}
 
-	public function is_duplicate() {
-		return $this->_duplicate;
+	public function isduplicate() {
+		return $this->duplicate;
 	}
 
 	public function duplicate_of_size() {
-		return $this->_duplicate_of_size;
+		return $this->duplicate_of_size;
 	}
 
 	/**

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -473,7 +473,7 @@ class Tiny_Image {
 
 	public function get_statistics( $active_sizes, $active_tinify_sizes ) {
 		if ( $this->statistics ) {
-			error_log( 'Strangely the image statistics are asked for again.' );
+			Tiny_Logger::error( 'Strangely the image statistics are asked for again.' );
 			return $this->statistics;
 		}
 

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -51,7 +51,8 @@ class Tiny_Image {
 		}
 
 		if ( ! is_array( $this->wp_metadata ) || ! isset( $this->wp_metadata['file'] ) ) {
-			/* No file metadata found, this might be another plugin messing with
+			/*
+			No file metadata found, this might be another plugin messing with
 				metadata. Simply ignore this! */
 			return;
 		}
@@ -63,7 +64,8 @@ class Tiny_Image {
 			$path_prefix .= $path_info['dirname'] . '/';
 		}
 
-		/* Do not use pathinfo for getting the filename.
+		/*
+		Do not use pathinfo for getting the filename.
 			It doesn't work when the filename starts with a special character. */
 		$path_parts                    = explode( '/', $this->wp_metadata['file'] );
 		$this->name                    = end( $path_parts );

--- a/src/class-tiny-logger.php
+++ b/src/class-tiny-logger.php
@@ -189,6 +189,7 @@ class Tiny_Logger {
 		$context_str = ! empty( $context ) ? ' ' . wp_json_encode( $context ) : '';
 		$log_entry   = "[{$timestamp}] [{$level_str}] {$message}{$context_str}" . PHP_EOL;
 
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( $log_entry, 3, $this->log_file_path );
 	}
 

--- a/src/class-tiny-logger.php
+++ b/src/class-tiny-logger.php
@@ -72,7 +72,7 @@ class Tiny_Logger {
 			'pre_update_option_tinypng_logging_enabled',
 			'Tiny_Logger::on_save_log_enabled',
 			10,
-			3
+			2
 		);
 	}
 
@@ -113,7 +113,7 @@ class Tiny_Logger {
 	 *
 	 * @return bool true if enabled
 	 */
-	public static function on_save_log_enabled( $log_enabled, $old, $option ) {
+	public static function on_save_log_enabled( $log_enabled, $old ) {
 		$instance              = self::get_instance();
 		$was_enabled           = 'on' === $old;
 		$is_now_enabled        = 'on' === $log_enabled;

--- a/src/class-tiny-logger.php
+++ b/src/class-tiny-logger.php
@@ -22,7 +22,6 @@
 /**
  * Handles logging of plugin events to file.
  *
- *
  * @since 3.7.0
  */
 class Tiny_Logger {

--- a/src/class-tiny-php.php
+++ b/src/class-tiny-php.php
@@ -37,8 +37,8 @@ class Tiny_PHP {
 	}
 
 	public static function client_supported() {
-		return Tiny_PHP::has_fully_supported_php() &&
-						Tiny_PHP::curl_available() &&
-						! Tiny_PHP::curl_exec_disabled();
+		return self::has_fully_supported_php() &&
+						self::curl_available() &&
+						! self::curl_exec_disabled();
 	}
 }

--- a/src/class-tiny-picture.php
+++ b/src/class-tiny-picture.php
@@ -109,7 +109,7 @@ class Tiny_Picture extends Tiny_WP_Base {
 	private function replace_img_sources( $content ) {
 		$image_sources = $this->filter_images( $content );
 		foreach ( $image_sources as $image_source ) {
-			$content = Tiny_Picture::replace_image( $content, $image_source );
+			$content = self::replace_image( $content, $image_source );
 		}
 		return $content;
 	}
@@ -145,7 +145,7 @@ class Tiny_Picture extends Tiny_WP_Base {
 	/**
 	 * Will add additional sourcesets to picture elements.
 	 *
-	 * @param string $content the full page content
+	 * @param string              $content the full page content
 	 * @param Tiny_Source_Picture $source the picture element
 	 *
 	 * @return string the updated content including augmented picture elements
@@ -159,7 +159,7 @@ class Tiny_Picture extends Tiny_WP_Base {
 	/**
 	 * Will replace img elements with picture elements that (possibly) have additional formats.
 	 *
-	 * @param string $content the full page content
+	 * @param string            $content the full page content
 	 * @param Tiny_Source_Image $source the picture element
 	 *
 	 * @return string the updated content including augmented picture elements

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -32,7 +32,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	}
 
 	public static function version() {
-		/* Avoid using get_plugin_data() because it is not loaded early enough
+		/*
+		Avoid using get_plugin_data() because it is not loaded early enough
 			in xmlrpc.php. */
 		return self::VERSION;
 	}
@@ -111,7 +112,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			$this->get_method( 'mark_image_as_compressed' )
 		);
 
-		/* When touching any functionality linked to image compressions when
+		/*
+		When touching any functionality linked to image compressions when
 			uploading images make sure it also works with XML-RPC. See README. */
 		add_filter(
 			'wp_ajax_nopriv_tiny_rpc',
@@ -788,7 +790,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			true
 		);
 
-		/* This might be deduplicated with the admin script localization, but
+		/*
+		This might be deduplicated with the admin script localization, but
 			the order of including scripts is sometimes different. So in that
 			case we need to make sure that the order of inclusion is correc.t */
 		wp_localize_script(
@@ -850,6 +853,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	 * Will clean up converted files (if any) when the original is deleted
 	 *
 	 * Hooked to the `delete_attachment` action.
+	 *
 	 * @see https://developer.wordpress.org/reference/hooks/deleted_post/
 	 *
 	 * @param [int] $post_id

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -699,7 +699,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			$location = add_query_arg( 'm', $_REQUEST['m'], $location );
 		}
 
-		wp_redirect( admin_url( $location ) );
+		wp_safe_redirect( admin_url( $location ) );
 		exit();
 	}
 

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -221,7 +221,8 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	protected static function get_intermediate_size( $size ) {
-		/* Inspired by
+		/*
+		Inspired by
 		http://codex.wordpress.org/Function_Reference/get_intermediate_image_sizes */
 		global $_wp_additional_image_sizes;
 
@@ -789,14 +790,12 @@ class Tiny_Settings extends Tiny_WP_Base {
 				if ( $this->get_api_key_pending() ) {
 					$this->clear_api_key_pending();
 				}
-			} else {
-				if ( $this->get_api_key_pending() ) {
+			} elseif ( $this->get_api_key_pending() ) {
 					$status->ok      = true;
 					$status->pending = true;
 					$status->message = (
 						'An email has been sent to activate your account'
 					);
-				}
 			}
 			include __DIR__ . '/views/account-status-connected.php';
 		}

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -98,7 +98,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		} catch ( Tiny_Exception $e ) {
 			$this->notices->show(
 				'compressor_exception',
-				esc_html( $e->getMessage(), 'tiny-compress-images' ),
+				esc_html( $e->getMessage() ),
 				'error',
 				false
 			);
@@ -379,7 +379,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		if ( $height > 0 ) {
 			$options['height'] = $height;
 		}
-		return sizeof( $options ) >= 2 ? $options : false;
+		return count( $options ) >= 2 ? $options : false;
 	}
 
 	/**
@@ -687,8 +687,8 @@ class Tiny_Settings extends Tiny_WP_Base {
 		}
 
 		$id    = sprintf( self::get_prefixed_name( 'compression_timing_%s' ), $value );
-		$label = esc_html( $label, 'tiny-compress-images' );
-		$desc  = esc_html( $desc, 'tiny-compress-images' );
+		$label = esc_html( $label );
+		$desc  = esc_html( $desc );
 		echo '<input type="radio" id="' . $id . '" name="' . $name .
 			'" value="' . $value . '" ' . $checked . '/>';
 		echo '<label for="' . $id . '">' . $label . '</label>';

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -48,6 +48,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		try {
 			$this->init_compressor();
 		} catch ( Tiny_Exception $e ) {
+			Tiny_Logger::error( $e->getMessage() );
 		}
 	}
 
@@ -55,6 +56,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		try {
 			$this->init_compressor();
 		} catch ( Tiny_Exception $e ) {
+			Tiny_Logger::error( $e->getMessage() );
 		}
 	}
 
@@ -62,6 +64,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		try {
 			$this->init_compressor();
 		} catch ( Tiny_Exception $e ) {
+			Tiny_Logger::error( $e->getMessage() );
 		}
 
 		add_action(
@@ -89,6 +92,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		try {
 			$this->init_compressor();
 		} catch ( Tiny_Exception $e ) {
+			Tiny_Logger::error( $e->getMessage() );
 		}
 	}
 

--- a/src/compatibility/as3cf/class-tiny-as3cf.php
+++ b/src/compatibility/as3cf/class-tiny-as3cf.php
@@ -62,7 +62,7 @@ class Tiny_AS3CF {
 	 * Registers hooks required for the AS3CF integration.
 	 */
 	public function add_hooks() {
-		add_action( 'as3cf_pre_upload_object', array( $this, 'as3cf_before_offload' ), 10, 2 );
+		add_action( 'as3cf_pre_upload_object', array( $this, 'as3cf_before_offload' ), 10, 1 );
 	}
 
 	/**
@@ -72,10 +72,9 @@ class Tiny_AS3CF {
 	 *
 	 * Will handle file before file is possibly offloaded
 	 *
-	 * @param Item  $as3cf_item
-	 * @param array $args
+	 * @param mixed $as3cf_item
 	 */
-	public function as3cf_before_offload( $as3cf_item, $args ) {
+	public function as3cf_before_offload( $as3cf_item ) {
 		if ( ! $this->tiny_settings->auto_compress_enabled() ) {
 			return;
 		}

--- a/src/compatibility/as3cf/class-tiny-as3cf.php
+++ b/src/compatibility/as3cf/class-tiny-as3cf.php
@@ -44,11 +44,11 @@ class Tiny_AS3CF {
 	 * Will verify if either the Lite or Pro version of AS3CF is active.
 	 */
 	public static function is_active() {
-		return Tiny_AS3CF::pro_is_active() || Tiny_AS3CF::lite_is_active();
+		return self::pro_is_active() || self::lite_is_active();
 	}
 
 	public static function remove_local_files_setting_enabled() {
-		if ( ! Tiny_AS3CF::is_active() ) {
+		if ( ! self::is_active() ) {
 			return false;
 		}
 		$settings = get_option( 'tantan_wordpress_s3' );

--- a/src/views/account-status-connected.php
+++ b/src/views/account-status-connected.php
@@ -51,23 +51,21 @@
 					$compressions
 				);
 			}
-		} else {
-			if ( isset( $status->message ) ) {
+		} elseif ( isset( $status->message ) ) {
 				echo esc_html__( 'Error', 'tiny-compress-images' ) . ': ';
 				echo esc_html( $status->message, 'tiny-compress-images' );
-			} else {
-				esc_html_e(
-					'API status could not be checked, enable cURL for more information',
-					'tiny-compress-images'
-				);
-			}
+		} else {
+			esc_html_e(
+				'API status could not be checked, enable cURL for more information',
+				'tiny-compress-images'
+			);
 		} // End if().
 		?>
 		</p>
 		<p>
 		<?php
 		if ( defined( 'TINY_API_KEY' ) ) {
-			echo sprintf(
+			printf(
 				/* translators: %s: wp-config.php */
 				esc_html__(
 					'The API key has been configured in %s',

--- a/src/views/account-status-connected.php
+++ b/src/views/account-status-connected.php
@@ -4,7 +4,7 @@
 		<?php
 		if ( $status->ok ) {
 			if ( isset( $status->message ) ) {
-				echo esc_html( $status->message, 'tiny-compress-images' );
+				echo esc_html( $status->message );
 			} else {
 				esc_html_e( 'Your account is connected', 'tiny-compress-images' );
 			}
@@ -53,7 +53,7 @@
 			}
 		} elseif ( isset( $status->message ) ) {
 				echo esc_html__( 'Error', 'tiny-compress-images' ) . ': ';
-				echo esc_html( $status->message, 'tiny-compress-images' );
+				echo esc_html( $status->message );
 		} else {
 			esc_html_e(
 				'API status could not be checked, enable cURL for more information',

--- a/src/views/bulk-optimization.php
+++ b/src/views/bulk-optimization.php
@@ -50,7 +50,7 @@ div.tiny-bulk-optimization div.dashboard div.optimize div.progressbar div.progre
 							esc_html_e( 'This page is designed to bulk optimize all your images.', 'tiny-compress-images' );
 							echo ' ';
 							esc_html_e( 'You do not seem to have uploaded any JPEG, PNG or WebP images yet.', 'tiny-compress-images' );
-						} elseif ( 0 == sizeof( $active_tinify_sizes ) ) {
+						} elseif ( 0 == count( $active_tinify_sizes ) ) {
 							esc_html_e( 'Based on your current settings, nothing will be optimized. There are no active sizes selected for optimization.', 'tiny-compress-images' );
 						} elseif ( 0 == $stats['available-unoptimized-sizes'] ) {
 							/* translators: %s: friendly user name */
@@ -115,7 +115,7 @@ div.tiny-bulk-optimization div.dashboard div.optimize div.progressbar div.progre
 								<div class="tooltip">
 									<span class="dashicons dashicons-info"></span>
 									<div class="tip">
-										<?php if ( $stats['uploaded-images'] > 0 && sizeof( $active_tinify_sizes ) > 0 && $stats['available-unoptimized-sizes'] > 0 ) { ?>
+										<?php if ( $stats['uploaded-images'] > 0 && count( $active_tinify_sizes ) > 0 && $stats['available-unoptimized-sizes'] > 0 ) { ?>
 											<p>
 												<?php
 												printf(
@@ -132,12 +132,12 @@ div.tiny-bulk-optimization div.dashboard div.optimize div.progressbar div.progre
 										<?php } ?>
 										<p>
 											<?php
-											if ( 0 == sizeof( $active_tinify_sizes ) ) {
+											if ( 0 == count( $active_tinify_sizes ) ) {
 												esc_html_e( 'Based on your current settings, nothing will be optimized. There are no active sizes selected for optimization.', 'tiny-compress-images' );
 											} else {
 												esc_html_e( 'These sizes are currently activated for optimization:', 'tiny-compress-images' );
 												echo '<ul>';
-												for ( $i = 0; $i < sizeof( $active_tinify_sizes ); ++$i ) {
+												for ( $i = 0; $i < count( $active_tinify_sizes ); ++$i ) {
 													$name = $active_tinify_sizes[ $i ];
 													if ( '0' == $name ) {
 														echo '<li>- ' . esc_html__( 'Original image', 'tiny-compress-images' ) . '</li>';
@@ -150,7 +150,7 @@ div.tiny-bulk-optimization div.dashboard div.optimize div.progressbar div.progre
 											?>
 										</p>
 										<p>
-										<?php if ( sizeof( $active_tinify_sizes ) > 0 ) { ?>
+										<?php if ( count( $active_tinify_sizes ) > 0 ) { ?>
 											<?php
 											printf(
 												wp_kses(

--- a/src/views/bulk-optimization.php
+++ b/src/views/bulk-optimization.php
@@ -137,7 +137,8 @@ div.tiny-bulk-optimization div.dashboard div.optimize div.progressbar div.progre
 											} else {
 												esc_html_e( 'These sizes are currently activated for optimization:', 'tiny-compress-images' );
 												echo '<ul>';
-												for ( $i = 0; $i < count( $active_tinify_sizes ); ++$i ) {
+												$active_tinify_sizes_count = count( $active_tinify_sizes );
+												for ( $i = 0; $i < $active_tinify_sizes_count; ++$i ) {
 													$name = $active_tinify_sizes[ $i ];
 													if ( '0' == $name ) {
 														echo '<li>- ' . esc_html__( 'Original image', 'tiny-compress-images' ) . '</li>';

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -105,7 +105,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 		<?php } ?>
 		<?php if ( $error ) { ?>
 			<span class="message error_message">
-				<?php echo esc_html__( 'Latest error', 'tiny-compress-images' ) . ': ' . esc_html( $error, 'tiny-compress-images' ); ?>
+				<?php echo esc_html__( 'Latest error', 'tiny-compress-images' ) . ': ' . esc_html( $error ); ?>
 			</span>
 			<br>
 		<?php } ?>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -166,7 +166,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 					echo '<td>';
 					echo '<span title="' . esc_html( basename( (string) $size->filename ) ) . '">';
 					echo ( Tiny_Image::is_original( $size_name ) ? esc_html__( 'Original', 'tiny-compress-images' ) : esc_html( ucfirst( rtrim( $size_name, '_wr2x' ) ) ) );
-					echo '</span>' . ' ';
+					echo '</span>';
 					if ( ! array_key_exists( $size_name, $active_sizes ) && ! Tiny_Image::is_retina( $size_name ) ) {
 						echo '<em>' . esc_html__( '(not in use)', 'tiny-compress-images' ) . '</em>';
 					} elseif ( $size->missing() && ( Tiny_Settings::wr2x_active() || ! Tiny_Image::is_retina( $size_name ) ) ) {

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -177,7 +177,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 						echo '<em>' . esc_html__( '(WP Retina 2x)', 'tiny-compress-images' ) . '</em>';
 					} elseif ( $size->resized() ) {
 						/* translators: %1$dx%2$d: resized image width x height */
-						printf( '<em>' . esc_html__( '(resized to %1$dx%2$d)', 'tiny-compress-images' ) . '</em>', $size->meta['output']['width'], $size->meta['output']['height'] );
+						printf( '<em>' . esc_html__( ' (resized to %1$dx%2$d)', 'tiny-compress-images' ) . '</em>', $size->meta['output']['width'], $size->meta['output']['height'] );
 					}
 					echo '</td>';
 

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -165,8 +165,8 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 					<?php
 					echo '<td>';
 					echo '<span title="' . esc_html( basename( (string) $size->filename ) ) . '">';
-					echo ( Tiny_Image::is_original( $size_name ) ? esc_html__( 'Original ', 'tiny-compress-images' ) : esc_html( ucfirst( rtrim( $size_name, '_wr2x' ) ) ) );
-					echo '</span>';
+					echo ( Tiny_Image::is_original( $size_name ) ? esc_html__( 'Original', 'tiny-compress-images' ) : esc_html( ucfirst( rtrim( $size_name, '_wr2x' ) ) ) );
+					echo ' </span>';
 					if ( ! array_key_exists( $size_name, $active_sizes ) && ! Tiny_Image::is_retina( $size_name ) ) {
 						echo '<em>' . esc_html__( '(not in use)', 'tiny-compress-images' ) . '</em>';
 					} elseif ( $size->missing() && ( Tiny_Settings::wr2x_active() || ! Tiny_Image::is_retina( $size_name ) ) ) {

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -165,7 +165,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 					<?php
 					echo '<td>';
 					echo '<span title="' . esc_html( basename( (string) $size->filename ) ) . '">';
-					echo ( Tiny_Image::is_original( $size_name ) ? esc_html__( 'Original', 'tiny-compress-images' ) : esc_html( ucfirst( rtrim( $size_name, '_wr2x' ) ) ) );
+					echo ( Tiny_Image::is_original( $size_name ) ? esc_html__( 'Original ', 'tiny-compress-images' ) : esc_html( ucfirst( rtrim( $size_name, '_wr2x' ) ) ) );
 					echo '</span>';
 					if ( ! array_key_exists( $size_name, $active_sizes ) && ! Tiny_Image::is_retina( $size_name ) ) {
 						echo '<em>' . esc_html__( '(not in use)', 'tiny-compress-images' ) . '</em>';
@@ -177,7 +177,7 @@ if ( ! empty( $_REQUEST['ids'] ) ) {
 						echo '<em>' . esc_html__( '(WP Retina 2x)', 'tiny-compress-images' ) . '</em>';
 					} elseif ( $size->resized() ) {
 						/* translators: %1$dx%2$d: resized image width x height */
-						printf( '<em>' . esc_html__( ' (resized to %1$dx%2$d)', 'tiny-compress-images' ) . '</em>', $size->meta['output']['width'], $size->meta['output']['height'] );
+						printf( '<em>' . esc_html__( '(resized to %1$dx%2$d)', 'tiny-compress-images' ) . '</em>', $size->meta['output']['width'], $size->meta['output']['height'] );
 					}
 					echo '</td>';
 

--- a/src/views/optimization-chart.php
+++ b/src/views/optimization-chart.php
@@ -33,7 +33,7 @@ div.tiny-optimization-chart div.value {
 <?php if ( isset( $stats ) ) { ?>
 	@keyframes shwoosh {
 		from {
-			stroke-dasharray: <?php echo '0' . ' ' . $chart['circle-size']; ?>
+			stroke-dasharray: <?php echo '0 ' . $chart['circle-size']; ?>
 		}
 		to {
 			stroke-dasharray: <?php echo $chart['dash-array-size'] . ' ' . $chart['circle-size']; ?>

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -106,6 +106,7 @@ class WordPressStubs
 		$this->addMethod('insert_with_markers');
 		$this->addMethod('esc_html_e');
 		$this->addMethod('esc_html');
+		$this->addMethod('maybe_unserialize');
 		$this->defaults();
 		$this->create_filesystem();
 	}
@@ -581,6 +582,15 @@ class WordPressMocks
 		}
 	
 		return file_put_contents($filename, trim($content) . "\n") !== false;
+	}
+
+	/**
+	 * Mocked function for https://developer.wordpress.org/reference/functions/maybe_unserialize/
+	 *
+	 * @return mixed
+	 */
+	public function maybe_unserialize($value) {
+		return unserialize($value);
 	}
 }
 


### PR DESCRIPTION
Running [PCP](wordpress.org/plugins/plugin-check/) will give over 200 violations. Running PHPCS with WordPress Guidelines will give even more. To stay compliant with plug-in guidelines I have increased strictness and also solves some of the issues. More will be incoming.

### Changes
**Fixed automatically by PHPCS**
c1d32aba4f093fcd969d0931c01dc1e1ba70703f 

**Manual Fixes**
* Remove unused parameters
  * 895274bda42cde7e4e13307d7fa5d500c7cf2f36
  * 3cfdfc60af0c0a200cc0300d88a18e95a59795bb
* change escaped translation string to non-translated escaped string. The strings were not translations.
  * b603f27c72fd62ba238a452ff62d36f5e4e2811f
  * a38d4e9cc1039397caa9bd558b33e552306ceb22
* replace sizeof() with count(). sizeof is an alias of count and count is preferred
  * 35720e52f21d0eb27d084db0f7a65de030071227
  * a38d4e9cc1039397caa9bd558b33e552306ceb22
* unnecessary string concat. Can simply use a single string.
  * c249d72b1601f9a7db3322701add490b0106defa
* empty catch. Log errors if catch fails
  * 8cdef0a01306be29158f7c163ace6bda6975c417
* underscores for private variables are not necessary
  * 941560bb111c27d14578055072fa306911542cf2
* move count outside loops
  * 2561c4988787ca6ca85f9267b1c3215f0119e8fd
* use wordpress functions instead of direct php functions
  * 136ddd8be9486799d2639a66ab1af8e14ff79fb3
  * a8edd2f236d378833d353301868f7c507fd3bdd5

