### PR TITLE
Union of compress & convert statistics

### DIFF
--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -125,13 +125,13 @@ class Tiny_Bulk_Optimization {
 			$image_stats = $tiny_image->get_statistics( $active_sizes, $active_tinify_sizes );
 
 			++$stats['uploaded-images'];
-			$stats['estimated_credit_use'] += $image_stats['available_uncompressed_sizes'];
+			$stats['estimated_credit_use']        += $image_stats['available_uncompressed_sizes'];
 			$stats['available-unoptimized-sizes'] += $image_stats['available_unoptimized_sizes'];
 			$stats['optimized-image-sizes']       += $image_stats['image_sizes_optimized'];
-			$stats['optimized-library-size']   += $image_stats['compressed_total_size'];
-			$stats['unoptimized-library-size'] += $image_stats['initial_total_size'];
+			$stats['optimized-library-size']      += $image_stats['compressed_total_size'];
+			$stats['unoptimized-library-size']    += $image_stats['initial_total_size'];
 
-			if ($conversion_enabled) {
+			if ( $conversion_enabled ) {
 				$stats['estimated_credit_use'] += $image_stats['available_unconverted_sizes'];
 			}
 

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -126,19 +126,8 @@ class Tiny_Bulk_Optimization {
 
 			++$stats['uploaded-images'];
 			$stats['estimated_credit_use'] += $image_stats['available_uncompressed_sizes'];
-			if ( $conversion_enabled ) {
-				$stats['available-unoptimized-sizes'] +=
-				$image_stats['available_unconverted_sizes'];
-				$stats['optimized-image-sizes']       +=
-				$image_stats['image_sizes_converted'];
-				$stats['estimated_credit_use']        +=
-					$image_stats['available_unconverted_sizes'];
-			} else {
-				$stats['available-unoptimized-sizes'] +=
-					$image_stats['available_uncompressed_sizes'];
-				$stats['optimized-image-sizes']       +=
-					$image_stats['image_sizes_compressed'];
-			}
+			$stats['available-unoptimized-sizes'] += $image_stats['available_unoptimized_sizes'];
+			$stats['optimized-image-sizes']       += $image_stats['image_sizes_optimized'];
 			$stats['optimized-library-size']   += $image_stats['compressed_total_size'];
 			$stats['unoptimized-library-size'] += $image_stats['initial_total_size'];
 

--- a/src/class-tiny-bulk-optimization.php
+++ b/src/class-tiny-bulk-optimization.php
@@ -131,6 +131,10 @@ class Tiny_Bulk_Optimization {
 			$stats['optimized-library-size']   += $image_stats['compressed_total_size'];
 			$stats['unoptimized-library-size'] += $image_stats['initial_total_size'];
 
+			if ($conversion_enabled) {
+				$stats['estimated_credit_use'] += $image_stats['available_unconverted_sizes'];
+			}
+
 			$has_conversions   = $image_stats['available_unconverted_sizes'] > 0;
 			$has_compressions  = $image_stats['available_uncompressed_sizes'] > 0;
 			$has_optimizations = $has_compressions || (

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -535,7 +535,8 @@ class Tiny_Image {
 				$needs_conversion  = $conversion_enabled && $size->unconverted();
 				if ( $needs_compression || $needs_conversion ) {
 					++$this->statistics['available_unoptimized_sizes'];
-				} elseif ( $size->compressed() && ( ! $conversion_enabled || $size->has_been_converted() ) ) {
+				} elseif ( $size->compressed() && ( ! $conversion_enabled
+					|| $size->has_been_converted() ) ) {
 					++$this->statistics['image_sizes_optimized'];
 				}
 			}

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -483,6 +483,10 @@ class Tiny_Image {
 		$this->statistics['available_uncompressed_sizes'] = 0;
 		$this->statistics['image_sizes_converted']        = 0;
 		$this->statistics['available_unconverted_sizes']  = 0;
+		$this->statistics['image_sizes_optimized']        = 0;
+		$this->statistics['available_unoptimized_sizes']  = 0;
+
+		$conversion_enabled = $this->settings->get_conversion_enabled();
 
 		foreach ( $this->sizes as $size_name => $size ) {
 			// skip duplicates or inactive sizes
@@ -525,6 +529,14 @@ class Tiny_Image {
 					++$this->statistics['image_sizes_converted'];
 				} else {
 					++$this->statistics['available_unconverted_sizes'];
+				}
+
+				$needs_compression = $size->uncompressed();
+				$needs_conversion  = $conversion_enabled && $size->unconverted();
+				if ( $needs_compression || $needs_conversion ) {
+					++$this->statistics['available_unoptimized_sizes'];
+				} elseif ( $size->compressed() && ( ! $conversion_enabled || $size->has_been_converted() ) ) {
+					++$this->statistics['image_sizes_optimized'];
 				}
 			}
 		}// End foreach().

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -613,7 +613,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		$result['message']                = $tiny_image->get_latest_error();
 		$result['image_sizes_compressed'] = $image_statistics['image_sizes_compressed'];
 		$result['image_sizes_converted']  = $image_statistics['image_sizes_converted'];
-		$result['image_sizes_optimized']  = $image_statistics['image_sizes_compressed'];
+		$result['image_sizes_optimized']  = $image_statistics['image_sizes_optimized'];
 
 		$result['initial_total_size'] = size_format(
 			$image_statistics['initial_total_size'],

--- a/test/unit/TinyImageEmptyTest.php
+++ b/test/unit/TinyImageEmptyTest.php
@@ -39,6 +39,8 @@ class Tiny_Image_Empty_Test extends Tiny_TestCase {
 			'available_uncompressed_sizes' => 4,
 			'available_unconverted_sizes' => 4,
 			'image_sizes_converted' => 0,
+			'image_sizes_optimized' => 0,
+			'available_unoptimized_sizes' => 4
 		), $this->subject->get_statistics( $active_sizes, $active_tinify_sizes ) );
 	}
 }

--- a/test/unit/TinyImageTest.php
+++ b/test/unit/TinyImageTest.php
@@ -164,7 +164,9 @@ class Tiny_Image_Test extends Tiny_TestCase {
 			'image_sizes_compressed' => 3,
 			'available_uncompressed_sizes' => 1,
 			'image_sizes_converted' => 0,
-			'available_unconverted_sizes' => 4
+			'available_unconverted_sizes' => 4,
+			'image_sizes_optimized' => 3,
+			'available_unoptimized_sizes' => 1,
 		), $this->subject->get_statistics( $active_sizes, $active_tinify_sizes ) );
 	}
 

--- a/test/unit/TinyImageTest.php
+++ b/test/unit/TinyImageTest.php
@@ -202,6 +202,32 @@ class Tiny_Image_Test extends Tiny_TestCase {
 		), $stats);
 	}
 
+	public function test_image_sizes_optimized_is_independent_of_image_sizes_compressed_when_conversion_is_pending() {
+		$this->wp->addOption( 'tinypng_convert_format', array(
+			'convert'    => 'on',
+			'convert_to' => 'smallest',
+		) );
+		$settings = new Tiny_Settings();
+		$subject  = new Tiny_Image( $settings, 1, $this->json( '_wp_attachment_metadata' ) );
+
+		$stats = $subject->get_statistics(
+			$settings->get_sizes(),
+			$settings->get_active_tinify_sizes()
+		);
+
+		$this->assertEquals( 3, $stats['image_sizes_compressed'],
+			'Three sizes have been compressed.'
+		);
+		$this->assertEquals( 0, $stats['image_sizes_optimized'],
+			'No sizes count as fully optimized because conversion has not been done but has been enabled.'
+		);
+		$this->assertNotEquals(
+			$stats['image_sizes_compressed'],
+			$stats['image_sizes_optimized'],
+			'the number of compressed images should not be equal to the number of optimized images.'
+		);
+	}
+
 	public function test_get_image_sizes_available_for_compression_when_file_modified() {
 		$active_sizes = $this->settings->get_sizes();
 		$active_tinify_sizes = $this->settings->get_active_tinify_sizes();

--- a/test/unit/TinyImageTest.php
+++ b/test/unit/TinyImageTest.php
@@ -156,8 +156,40 @@ class Tiny_Image_Test extends Tiny_TestCase {
 	}
 
 	public function test_get_statistics() {
-		$active_sizes = $this->settings->get_sizes();
-		$active_tinify_sizes = $this->settings->get_active_tinify_sizes();
+			$this->wp->addOption( 'tinypng_convert_format', array(
+				'convert'    => 'off',
+			) );
+			$settings = new Tiny_Settings();
+			$subject  = new Tiny_Image( $settings, 1, $this->json( '_wp_attachment_metadata' ) );
+		
+			$active_sizes        = $settings->get_sizes();
+			$active_tinify_sizes = $settings->get_active_tinify_sizes();
+			$stats               = $subject->get_statistics( $active_sizes, $active_tinify_sizes );
+		
+			$this->assertEquals( array(
+				'initial_total_size' => 360542,
+				'compressed_total_size' => 328670,
+				'image_sizes_compressed' => 3,
+				'available_uncompressed_sizes' => 1,
+				'image_sizes_converted' => 0,
+				'available_unconverted_sizes' => 4,
+				'image_sizes_optimized' => 3,
+				'available_unoptimized_sizes' => 1,
+			), $stats);
+	}
+
+	public function test_get_statistics_with_conversion_enabled() {
+		$this->wp->addOption( 'tinypng_convert_format', array(
+			'convert'    => 'on',
+			'convert_to' => 'smallest',
+		) );
+		$settings = new Tiny_Settings();
+		$subject  = new Tiny_Image( $settings, 1, $this->json( '_wp_attachment_metadata' ) );
+	
+		$active_sizes        = $settings->get_sizes();
+		$active_tinify_sizes = $settings->get_active_tinify_sizes();
+		$stats               = $subject->get_statistics( $active_sizes, $active_tinify_sizes );
+		
 		$this->assertEquals( array(
 			'initial_total_size' => 360542,
 			'compressed_total_size' => 328670,
@@ -165,9 +197,9 @@ class Tiny_Image_Test extends Tiny_TestCase {
 			'available_uncompressed_sizes' => 1,
 			'image_sizes_converted' => 0,
 			'available_unconverted_sizes' => 4,
-			'image_sizes_optimized' => 3,
-			'available_unoptimized_sizes' => 1,
-		), $this->subject->get_statistics( $active_sizes, $active_tinify_sizes ) );
+			'image_sizes_optimized' => 0,
+			'available_unoptimized_sizes' => 4,
+		), $stats);
 	}
 
 	public function test_get_image_sizes_available_for_compression_when_file_modified() {


### PR DESCRIPTION
When conversion was enabled, the image statistics assumed a image was "optimized" when it was converted. This works because you cannot convert without compressing. But it stops working when the image is modified externally making it compressed but still converted.

This change changes the definition of optimized. An image is optimised when it is converted _and_ compressed.

**Changes**
- `src/class-tiny-bulk-optimization.php`
  - will simply set the result of the statistics to available-unoptimized-sizes and optimized-image-sizes
  - will only count additional credits when conversion is enabled
- `src/class-tiny-image.php`
  - adds `image_sizes_optimized` and `optimized-image-sizes` to the statistics.
  - will increment `available_unoptimized_sizes` when it is either uncompressed or unconverted
  - will increment `image_sizes_optimized` when it compressed AND converted
