### PR TITLE
PHPCS - WordPress.Security.NonceVerification

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,9 +10,6 @@
     <exclude name="Generic.Commenting" />
     <exclude name="Squiz.PHP.CommentedOutCode.Found" />
 
-    <!-- Fix security issues -->
-    <exclude name="WordPress.Security.NonceVerification" />
-
     <!-- Fix AlternativeFunctons-->
     <exclude name="WordPress.WP.AlternativeFunctions" />
     <exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -133,7 +133,7 @@ class Tiny_Helpers {
 		);
 
 		foreach ( $pagebuilder_keys as $key ) {
-			if ( filter_has_var(INPUT_GET, $key ) ) {
+			if ( filter_has_var( INPUT_GET, $key ) ) {
 				return true;
 			}
 		}

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -112,36 +112,6 @@ class Tiny_Helpers {
 
 
 	/**
-	 * Checks wether a user is viewing from a page builder
-	 *
-	 * @since 3.6.5
-	 */
-	public static function is_pagebuilder_request() {
-		$pagebuilder_keys = array(
-			'fl_builder', // Beaver Builder
-			'et_fb', // Divi Builder
-			'bricks', // Bricks Builder
-			'breakdance', // Breakdance Builder
-			'breakdance_browser', // Breakdance Builder
-			'ct_builder', // Oxygen Builder
-			'fb-edit', // Avada Live Builder
-			'builder', // Avada Live Builder
-			'spio_no_cdn', // Site Origin
-			'tatsu', // Tatsu Builder
-			'tve', // Thrive Architect
-			'tcbf', // Thrive Architect
-		);
-
-		foreach ( $pagebuilder_keys as $key ) {
-			if ( filter_has_var( INPUT_GET, $key ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Gets or initializes the WordPress filesystem instance.
 	 *
 	 * Returns the global WP_Filesystem instance, initializing it if necessary.

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -133,7 +133,7 @@ class Tiny_Helpers {
 		);
 
 		foreach ( $pagebuilder_keys as $key ) {
-			if ( isset( $_GET[ $key ] ) ) {
+			if ( filter_has_var(INPUT_GET, $key ) ) {
 				return true;
 			}
 		}

--- a/src/class-tiny-notices.php
+++ b/src/class-tiny-notices.php
@@ -148,7 +148,7 @@ class Tiny_Notices extends Tiny_WP_Base {
 	}
 
 	public function dismiss() {
-		if ( empty( $_POST['name'] ) || ! $this->check_ajax_referer() ) {
+		if ( ! check_ajax_referer( 'tiny-compress', '_nonce', false ) || empty( $_POST['name'] ) ) {
 			echo json_encode( false );
 			exit();
 		}

--- a/src/class-tiny-picture.php
+++ b/src/class-tiny-picture.php
@@ -65,11 +65,60 @@ class Tiny_Picture extends Tiny_WP_Base {
 			return;
 		}
 
-		if ( Tiny_Helpers::is_pagebuilder_request() ) {
+		if ( static::is_pagebuilder_request() ) {
 			return;
 		}
 
 		add_action( 'template_redirect', array( $this, 'on_template_redirect' ) );
+	}
+
+	/**
+	 * Checks whether the current request originates from a page builder.
+	 *
+	 * Detects known page builder query parameters to prevent picture-element
+	 * injection from interfering with builder previews.
+	 *
+	 * @since 3.6.5
+	 *
+	 * @return bool True if a page builder query parameter is present.
+	 */
+	protected static function is_pagebuilder_request() {
+		$pagebuilder_keys = array(
+			'fl_builder',        // Beaver Builder
+			'et_fb',             // Divi Builder
+			'bricks',            // Bricks Builder
+			'breakdance',        // Breakdance Builder
+			'breakdance_browser', // Breakdance Builder
+			'ct_builder',        // Oxygen Builder
+			'fb-edit',           // Avada Live Builder
+			'builder',           // Avada Live Builder
+			'spio_no_cdn',       // Site Origin
+			'tatsu',             // Tatsu Builder
+			'tve',               // Thrive Architect
+			'tcbf',              // Thrive Architect
+		);
+
+		foreach ( $pagebuilder_keys as $key ) {
+			if ( static::has_get_var( $key ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether a GET variable exists in the original request.
+	 *
+	 * Wraps filter_has_var() to allow overriding in tests via late static binding.
+	 *
+	 * @since 3.6.5
+	 *
+	 * @param string $key The query string key to check.
+	 * @return bool True if the key exists in the original GET request.
+	 */
+	protected static function has_get_var( $key ) {
+		return filter_has_var( INPUT_GET, $key );
 	}
 
 	public function on_template_redirect() {

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -517,9 +517,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	 *               or success array ['data' => [$id, $metadata]]
 	 */
 	private function validate_ajax_attachment_request() {
-		if ( ! check_ajax_referer( 'tiny-compress', '_nonce', false ) ) {
-			exit();
-		}
+		check_ajax_referer( 'tiny-compress', '_nonce' );
+
 		if ( ! current_user_can( 'upload_files' ) ) {
 			return array(
 				'error' => esc_html__(
@@ -658,7 +657,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	}
 
 	public function ajax_optimization_statistics() {
-		if ( $this->check_ajax_referer() && current_user_can( 'upload_files' ) ) {
+		if ( check_ajax_referer( 'tiny-compress', '_nonce', false ) && current_user_can( 'upload_files' ) ) {
 			$stats = Tiny_Bulk_Optimization::get_optimization_statistics( $this->settings );
 			echo json_encode( $stats );
 		}

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -765,7 +765,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		$images_to_compress = array();
 
 		if ( ! empty( $_GET['ids'] ) ) {
-			$nonce = isset( $_GET['_tiny_nonce'] ) ? sanitize_key( wp_unslash( $_GET['_tiny_nonce'] ) ) : '';
+			$nonce = isset( $_GET['_tiny_nonce'] ) ?
+				sanitize_key( wp_unslash( $_GET['_tiny_nonce'] ) ) : '';
 
 			if ( $nonce && wp_verify_nonce( $nonce, 'tiny-bulk-ids' ) ) {
 				$request_ids        = sanitize_text_field( wp_unslash( $_GET['ids'] ) );

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -657,7 +657,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	}
 
 	public function ajax_optimization_statistics() {
-		if ( check_ajax_referer( 'tiny-compress', '_nonce', false ) && current_user_can( 'upload_files' ) ) {
+		if ( check_ajax_referer( 'tiny-compress', '_nonce', false ) &&
+			current_user_can( 'upload_files' ) ) {
 			$stats = Tiny_Bulk_Optimization::get_optimization_statistics( $this->settings );
 			echo json_encode( $stats );
 		}

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -517,7 +517,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	 *               or success array ['data' => [$id, $metadata]]
 	 */
 	private function validate_ajax_attachment_request() {
-		if ( ! $this->check_ajax_referer() ) {
+		if ( ! check_ajax_referer( 'tiny-compress', '_nonce', false ) ) {
 			exit();
 		}
 		if ( ! current_user_can( 'upload_files' ) ) {
@@ -614,11 +614,14 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		);
 		wp_update_attachment_metadata( $id, $tiny_image->get_wp_metadata() );
 
+		// Nonce verified in validate_ajax_attachment_request().
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$current_library_size = isset( $_POST['current_size'] ) ?
 			intval( wp_unslash( $_POST['current_size'] ) )
 			: 0;
-		$size_after           = $image_statistics['compressed_total_size'];
-		$new_library_size     = $current_library_size + $size_after - $size_before;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		$size_after       = $image_statistics['compressed_total_size'];
+		$new_library_size = $current_library_size + $size_after - $size_before;
 
 		$result['message']                = $tiny_image->get_latest_error();
 		$result['image_sizes_compressed'] = $image_statistics['image_sizes_compressed'];

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -764,19 +764,13 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	private function render_compress_details( $tiny_image ) {
 		$images_to_compress = array();
 
-		if ( ! empty( $_REQUEST['ids'] ) ) {
-			if (
-				! isset( $_REQUEST['_tiny_nonce'] ) ||
-				! wp_verify_nonce(
-					sanitize_key( wp_unslash( $_REQUEST['_tiny_nonce'] ) ),
-					'tiny-bulk-ids'
-				)
-			) {
-				return;
-			}
+		if ( ! empty( $_GET['ids'] ) ) {
+			$nonce = isset( $_GET['_tiny_nonce'] ) ? sanitize_key( wp_unslash( $_GET['_tiny_nonce'] ) ) : '';
 
-			$request_ids        = sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) );
-			$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
+			if ( $nonce && wp_verify_nonce( $nonce, 'tiny-bulk-ids' ) ) {
+ 				$request_ids        = sanitize_text_field( wp_unslash( $_GET['ids'] ) );
+ 				$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
+ 			}
 		}
 
 		$in_progress = $tiny_image->filter_image_sizes( 'in_progress' );

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -768,9 +768,9 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			$nonce = isset( $_GET['_tiny_nonce'] ) ? sanitize_key( wp_unslash( $_GET['_tiny_nonce'] ) ) : '';
 
 			if ( $nonce && wp_verify_nonce( $nonce, 'tiny-bulk-ids' ) ) {
- 				$request_ids        = sanitize_text_field( wp_unslash( $_GET['ids'] ) );
- 				$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
- 			}
+				$request_ids        = sanitize_text_field( wp_unslash( $_GET['ids'] ) );
+				$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
+			}
 		}
 
 		$in_progress = $tiny_image->filter_image_sizes( 'in_progress' );
@@ -831,7 +831,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		/*
 		This might be deduplicated with the admin script localization, but
 			the order of including scripts is sometimes different. So in that
-			case we need to make sure that the order of inclusion is correc.t */
+			case we need to make sure that the order of inclusion is correct. */
 		wp_localize_script(
 			self::NAME . '_dashboard_widget',
 			'tinyCompressDashboard',

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -703,6 +703,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		$location = 'upload.php?mode=list&ids=' . $ids;
 
 		$location = add_query_arg( 'action', $action, $location );
+		$location = add_query_arg( '_tiny_nonce', wp_create_nonce( 'tiny-bulk-ids' ), $location );
 
 		if ( ! empty( $_REQUEST['paged'] ) ) {
 			$location = add_query_arg( 'paged', absint( $_REQUEST['paged'] ), $location );
@@ -758,6 +759,23 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	}
 
 	private function render_compress_details( $tiny_image ) {
+		$images_to_compress = array();
+
+		if ( ! empty( $_REQUEST['ids'] ) ) {
+			if (
+				! isset( $_REQUEST['_tiny_nonce'] ) ||
+				! wp_verify_nonce(
+					sanitize_key( wp_unslash( $_REQUEST['_tiny_nonce'] ) ),
+					'tiny-bulk-ids'
+				)
+			) {
+				return;
+			}
+
+			$request_ids        = sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) );
+			$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
+		}
+
 		$in_progress = $tiny_image->filter_image_sizes( 'in_progress' );
 		if ( count( $in_progress ) > 0 ) {
 			include __DIR__ . '/views/compress-details-processing.php';

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -827,9 +827,8 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function create_api_key() {
-		if ( ! check_ajax_referer( 'tiny-compress', '_nonce' ) ) {
-			exit;
-		}
+		check_ajax_referer( 'tiny-compress', '_nonce' );
+
 		$compressor = $this->get_compressor();
 		if ( ! current_user_can( 'manage_options' ) ) {
 			$status = (object) array(
@@ -905,9 +904,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function update_api_key() {
-		if ( ! check_ajax_referer( 'tiny-compress', '_nonce' ) ) {
-			exit;
-		}
+		check_ajax_referer( 'tiny-compress', '_nonce' );
 
 		$key = null;
 		if ( ! current_user_can( 'manage_options' ) ) {

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -827,7 +827,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function create_api_key() {
-		if ( ! $this->check_ajax_referer() ) {
+		if ( ! check_ajax_referer( 'tiny-compress', '_nonce' ) ) {
 			exit;
 		}
 		$compressor = $this->get_compressor();

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -160,7 +160,9 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function image_sizes_notice() {
-		if ( current_user_can( 'manage_options' ) && check_ajax_referer( 'tiny-compress' ) ) {
+		check_ajax_referer( 'tiny-compress' );
+
+		if ( current_user_can( 'manage_options' ) ) {
 			$selected_sizes = isset( $_GET['image_sizes_selected'] ) ?
 				intval( $_GET['image_sizes_selected'] ) : 0;
 			$this->render_size_checkboxes_description(

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -160,7 +160,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function image_sizes_notice() {
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( 'manage_options' ) && check_ajax_referer( 'tiny-compress' ) ) {
 			$selected_sizes = isset( $_GET['image_sizes_selected'] ) ?
 				intval( $_GET['image_sizes_selected'] ) : 0;
 			$this->render_size_checkboxes_description(

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -905,7 +905,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function update_api_key() {
-		if ( ! $this->check_ajax_referer() ) {
+		if ( ! check_ajax_referer( 'tiny-compress', '_nonce' ) ) {
 			exit;
 		}
 

--- a/src/class-tiny-wp-base.php
+++ b/src/class-tiny-wp-base.php
@@ -87,10 +87,6 @@ abstract class Tiny_WP_Base {
 		return get_current_user_id();
 	}
 
-	protected function check_ajax_referer() {
-		return check_ajax_referer( 'tiny-compress', '_nonce', false );
-	}
-
 	public function init() {
 	}
 

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -345,9 +345,13 @@
       if (compressWr2x) {
         image_count_url += '&compress_wr2x=true';
       }
-
-      const sizeDescriptionHtml = await fetch(image_count_url).then(r => r.text());
-      document.querySelector('#tiny-image-sizes-notice').innerHTML = sizeDescriptionHtml;
+      try {
+        const sizeDescriptionHtml = await fetch(image_count_url).then(r => r.text());
+        document.querySelector('#tiny-image-sizes-notice').innerHTML = sizeDescriptionHtml;
+      } catch (err) {
+        document.querySelector('#tiny-image-sizes-notice').innerHTML = '';
+        console.error(err);
+      }
     }
 
     eventOn('click', 'input[name*=tinypng_sizes], #tinypng_resize_original_enabled', refreshSizeDescriptionNotice);

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -329,29 +329,30 @@
       });
     }
 
-    eventOn('click', 'input[name*=tinypng_sizes], #tinypng_resize_original_enabled', function() {
-      /* Unfortunately, we need some additional information to display
-         the correct notice. */
-      var totalSelectedSizes = jQuery('input[name*=tinypng_sizes]:checked').length;
-      var compressWr2x = propOf('#tinypng_sizes_wr2x', 'checked');
-      if (compressWr2x) {
-        totalSelectedSizes--;
-      }
+    async function refreshSizeDescriptionNotice() {
+      const totalSelectedSizes = document.querySelectorAll('input[name*=tinypng_sizes]:checked').length;
+      const compressWr2x = document.querySelector('#tinypng_sizes_wr2x')?.checked ?? false;
+      const selectedCount = compressWr2x ? totalSelectedSizes - 1 : totalSelectedSizes;
 
-      var image_count_url = ajaxurl + (ajaxurl.indexOf( '?' ) > 0 ? '&' : '?') + 'action=tiny_image_sizes_notice&image_sizes_selected=' + totalSelectedSizes;
-      if (propOf('#tinypng_resize_original_enabled', 'checked') && propOf('#tinypng_sizes_0', 'checked')) {
+      const separator = ajaxurl.includes('?') ? '&' : '?';
+      let image_count_url = `${ajaxurl}${separator}action=tiny_image_sizes_notice&image_sizes_selected=${selectedCount}&_ajax_nonce=${tinyCompress.nonce}`;
+
+      const resizeOriginalChecked = document.querySelector('#tinypng_resize_original_enabled')?.checked;
+      const compressOriginalChecked = document.querySelector('#tinypng_sizes_0')?.checked;
+      if (resizeOriginalChecked && compressOriginalChecked) {
         image_count_url += '&resize_original=true';
       }
       if (compressWr2x) {
         image_count_url += '&compress_wr2x=true';
       }
-      jQuery('#tiny-image-sizes-notice').load(image_count_url);
-    });
 
-    eventOn('click', '#tinypng_auto_compress_enabled', function() {
-      updateSettings();
-    });
+      const sizeDescriptionHtml = await fetch(image_count_url).then(r => r.text());
+      document.querySelector('#tiny-image-sizes-notice').innerHTML = sizeDescriptionHtml;
+    }
 
+    eventOn('click', 'input[name*=tinypng_sizes], #tinypng_resize_original_enabled', refreshSizeDescriptionNotice);
+    
+    eventOn('click', '#tinypng_auto_compress_enabled', updateSettings);
     jQuery('#tinypng_sizes_0, #tinypng_resize_original_enabled').click(updateSettings);
     updateSettings();
   }

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -301,7 +301,6 @@
     eventOn('click', 'button.tiny-mark-as-compressed', onClickButtonMarkAsCompressed);
 
     setPropOf('button.tiny-compress', 'disabled', null);
-    
     compressImageSelection();
     watchCompressingImages();
 
@@ -335,18 +334,18 @@
       const selectedCount = compressWr2x ? totalSelectedSizes - 1 : totalSelectedSizes;
 
       const separator = ajaxurl.includes('?') ? '&' : '?';
-      let image_count_url = `${ajaxurl}${separator}action=tiny_image_sizes_notice&image_sizes_selected=${selectedCount}&_ajax_nonce=${tinyCompress.nonce}`;
+      let imageCountUrl = `${ajaxurl}${separator}action=tiny_image_sizes_notice&image_sizes_selected=${selectedCount}&_ajax_nonce=${tinyCompress.nonce}`;
 
       const resizeOriginalChecked = document.querySelector('#tinypng_resize_original_enabled')?.checked;
       const compressOriginalChecked = document.querySelector('#tinypng_sizes_0')?.checked;
       if (resizeOriginalChecked && compressOriginalChecked) {
-        image_count_url += '&resize_original=true';
+        imageCountUrl += '&resize_original=true';
       }
       if (compressWr2x) {
-        image_count_url += '&compress_wr2x=true';
+        imageCountUrl += '&compress_wr2x=true';
       }
       try {
-        const sizeDescriptionHtml = await fetch(image_count_url).then(r => r.text());
+        const sizeDescriptionHtml = await fetch(imageCountUrl).then(r => r.text());
         document.querySelector('#tiny-image-sizes-notice').innerHTML = sizeDescriptionHtml;
       } catch (err) {
         document.querySelector('#tiny-image-sizes-notice').innerHTML = '';
@@ -355,7 +354,6 @@
     }
 
     eventOn('click', 'input[name*=tinypng_sizes], #tinypng_resize_original_enabled', refreshSizeDescriptionNotice);
-    
     eventOn('click', '#tinypng_auto_compress_enabled', updateSettings);
     jQuery('#tinypng_sizes_0, #tinypng_resize_original_enabled').click(updateSettings);
     updateSettings();

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -2,8 +2,9 @@
 /**
  * Compression details on media overview page.
  *
- * @var Tiny_Plugin $this       The plugin instance.
- * @var Tiny_Image  $tiny_image The image being compressed.
+ * @var Tiny_Plugin $this               The plugin instance.
+ * @var Tiny_Image  $tiny_image         The image being compressed.
+ * @var int[]       $images_to_compress The IDs that are being compressed
  */
 
 $available_sizes              = array_keys( $this->settings->get_sizes() );
@@ -22,11 +23,6 @@ $size_active = array_fill_keys( $active_tinify_sizes, true );
 $size_exists = array_fill_keys( $available_sizes, true );
 ksort( $size_exists );
 
-$images_to_compress = array();
-if ( ! empty( $_REQUEST['ids'] ) ) {
-	$request_ids        = sanitize_text_field( wp_unslash( $_REQUEST['ids'] ) );
-	$images_to_compress = array_map( 'intval', explode( '-', $request_ids ) );
-}
 ?>
 <div class="details-container">
 	<div class="details">

--- a/test/unit/TinyHelpersTest.php
+++ b/test/unit/TinyHelpersTest.php
@@ -111,26 +111,6 @@ public function test_uppercase_extension_and_mimetype_case_insensitive()
     $this->assertEquals($expected, Tiny_Helpers::replace_file_extension('image/avif', $input));
 }
 
-public function test_is_pagebuilder_request_returns_false_when_no_pagebuilder_keys()
-{
-    $_GET = array();
-    $this->assertFalse(Tiny_Helpers::is_pagebuilder_request());
-}
-
-public function test_is_pagebuilder_request_returns_true_for_beaver_builder()
-{
-    $_GET = array('fl_builder' => '1');
-    $this->assertTrue(Tiny_Helpers::is_pagebuilder_request());
-    $_GET = array();
-}
-
-public function test_is_pagebuilder_request_returns_false_for_non_pagebuilder_keys()
-{
-    $_GET = array('page' => 'settings', 'post_id' => '123');
-    $this->assertFalse(Tiny_Helpers::is_pagebuilder_request());
-    $_GET = array();
-}
-
 public function test_str_starts_with_returns_true_when_haystack_starts_with_needle()
 {
     $this->assertTrue(Tiny_Helpers::str_starts_with('hello world', 'hello'));

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -2,6 +2,19 @@
 
 require_once dirname(__FILE__) . '/TinyTestCase.php';
 
+class Tiny_Picture_Overrides extends Tiny_Picture {
+    /**
+     * filter_has_var looks for immutable $_GET
+     * so unit tests cannot set the $_GET.
+     * 
+     * isset( $_GET ) is similar to filter_has_var
+     * but allows us to mutate.
+     */
+	protected static function has_get_var( $key ) {
+		return isset( $_GET[ $key ] );
+	}
+}
+
 class Tiny_Picture_Test extends Tiny_TestCase
 {
 
@@ -337,7 +350,7 @@ class Tiny_Picture_Test extends Tiny_TestCase
         });
         
         $settings = new Tiny_Settings();
-        $tiny_picture = new Tiny_Picture($settings, $this->vfs->url(), array('https://www.tinifytest.com'));
+        $tiny_picture = new Tiny_Picture_Overrides($settings, $this->vfs->url(), array('https://www.tinifytest.com'));
 
         $template_redirect_registered = false;
         foreach ($this->wp->getCalls('add_action') as $call) {

--- a/test/unit/TinyPictureTest.php
+++ b/test/unit/TinyPictureTest.php
@@ -2,17 +2,19 @@
 
 require_once dirname(__FILE__) . '/TinyTestCase.php';
 
-class Tiny_Picture_Overrides extends Tiny_Picture {
+class Tiny_Picture_Overrides extends Tiny_Picture
+{
     /**
-     * filter_has_var looks for immutable $_GET
-     * so unit tests cannot set the $_GET.
-     * 
-     * isset( $_GET ) is similar to filter_has_var
-     * but allows us to mutate.
+     * filter_has_var() looks for immutable $_GET,
+     * so unit tests cannot set $_GET.
+     *
+     * isset( $_GET[ $key ] ) is similar to filter_has_var(),
+     * but allows us to mutate it in tests.
      */
-	protected static function has_get_var( $key ) {
-		return isset( $_GET[ $key ] );
-	}
+    protected static function has_get_var($key)
+    {
+        return isset($_GET[$key]);
+    }
 }
 
 class Tiny_Picture_Test extends Tiny_TestCase
@@ -344,11 +346,11 @@ class Tiny_Picture_Test extends Tiny_TestCase
     public function test_does_not_register_hooks_when_pagebuilder_request()
     {
         $_GET = array('fl_builder' => '1');
-        
+
         $this->wp->stub('is_admin', function () {
             return false;
         });
-        
+
         $settings = new Tiny_Settings();
         $tiny_picture = new Tiny_Picture_Overrides($settings, $this->vfs->url(), array('https://www.tinifytest.com'));
 
@@ -364,14 +366,15 @@ class Tiny_Picture_Test extends Tiny_TestCase
             $template_redirect_registered,
             'Tiny_Picture should not register template_redirect hook when pagebuilder is active'
         );
-        
+
         $_GET = array();
     }
 
     /**
      * images that have no src or srcset will be unchanged
      */
-    public function test_image_without_src() {
+    public function test_image_without_src()
+    {
         $input = '<img alt="no source">';
         $expected = '<img alt="no source">';
         $output = $this->tiny_picture->replace_sources($input);
@@ -382,7 +385,8 @@ class Tiny_Picture_Test extends Tiny_TestCase
     /**
      * sizes attribute on <img> also have to be set  to <source> elements
      */
-    public function test_img_sizes_attribute_is_propagated_to_sources() {
+    public function test_img_sizes_attribute_is_propagated_to_sources()
+    {
         $this->wp->createImage(1000, '2026/04', 'test-320w.webp');
         $this->wp->createImage(1000, '2026/04', 'test-640w.webp');
         $this->wp->createImage(1000, '2026/04', 'test.webp');
@@ -397,7 +401,8 @@ class Tiny_Picture_Test extends Tiny_TestCase
     /**
      * Images with only a srcset are valid and will be wrapped
      */
-    public function test_image_with_only_srcset() {
+    public function test_image_with_only_srcset()
+    {
         $this->wp->createImage(37857, '2025/09', 'test_250x250.webp');
 
         $input = '<img srcset="/wp-content/uploads/2025/09/test_250x250.png 350w" alt="no source but has srcset">';


### PR DESCRIPTION
Solved every violation of WordPress.Security.NonceVerification

**Changes**
- Remove the phpcs exclusion rule
- A tricky issue with the pagebuilder check. When working in a pagebuilder we didn't want to transform images to picture elements. Therefor we check for known pagebuilder parameters and skip transformation if we found one. When accessing the parameter we did not have a nonce check nor can have one because the parameters are set outside our domain. Fortunately filter_has_var is enough to verify the presence of a parameter so we can replace it. `filter_has_var` only reads from the initial input parameter so our unit tests cannot set $_GET. This forced me to override the variable check in the test.
- The ajax call for notifications did not contain a nonce. This has been added in admin.js. I also modernized the js and replaced jquery calls with plain js.
- removed the base check_ajax_referer and replaced it with core check_ajax_referer. This allows phpcs to be valid and we can steer its behaviour a bit better.