### PR TITLE
compress unscaled when original is active

### DIFF
--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -557,6 +557,15 @@ class Tiny_Image {
 		return self::ORIGINAL === $size;
 	}
 
+
+	/**
+	 * Check wether given $size is the original_unscaled image size.
+	 *
+	 * @since 3.6.14
+	 *
+	 * @param string $size the size descriptor
+	 * @return bool true if size is the original unscaled image
+	 */
 	public static function is_original_unscaled( $size ) {
 		return self::ORIGINAL_UNSCALED === $size;
 	}

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -19,7 +19,8 @@
 */
 
 class Tiny_Image {
-	const ORIGINAL = 0;
+	const ORIGINAL          = 0;
+	const ORIGINAL_UNSCALED = 'original_unscaled';
 
 	/** @var Tiny_Settings */
 	private $settings;
@@ -71,6 +72,12 @@ class Tiny_Image {
 		$this->name                    = end( $path_parts );
 		$filename                      = $path_prefix . $this->name;
 		$this->sizes[ self::ORIGINAL ] = new Tiny_Image_Size( $filename );
+
+		if ( isset( $this->wp_metadata['original_image'] ) ) {
+			$this->sizes[ self::ORIGINAL_UNSCALED ] = new Tiny_Image_Size(
+				$path_prefix . $this->wp_metadata['original_image']
+			);
+		}
 
 		// Ensure 'sizes' exists and is an array to prevent PHP Warnings
 		$sizes = isset( $this->wp_metadata['sizes'] ) && is_array( $this->wp_metadata['sizes'] )
@@ -548,6 +555,10 @@ class Tiny_Image {
 
 	public static function is_original( $size ) {
 		return self::ORIGINAL === $size;
+	}
+
+	public static function is_original_unscaled( $size ) {
+		return self::ORIGINAL_UNSCALED === $size;
 	}
 
 	public static function is_retina( $size ) {

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -75,7 +75,7 @@ class Tiny_Image {
 
 		if ( isset( $this->wp_metadata['original_image'] ) ) {
 			$this->sizes[ self::ORIGINAL_UNSCALED ] = new Tiny_Image_Size(
-				$path_prefix . $this->wp_metadata['original_image']
+				$path_prefix . wp_basename( $this->wp_metadata['original_image'] )
 			);
 		}
 
@@ -91,7 +91,7 @@ class Tiny_Image {
 				// Add to sanitized metadata
 				$sanitized_sizes[ $size_name ] = $size_info;
 				$this->sizes[ $size_name ]     = new Tiny_Image_Size(
-					$path_prefix . $size_info['file']
+					$path_prefix . wp_basename( $size_info['file'] )
 				);
 			}
 		}

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -568,7 +568,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 			esc_attr( $dummy_size_name ) . '" value="on"/>';
 
 		foreach ( $this->get_sizes() as $size => $option ) {
-			if ( Tiny_Image::is_original_unscaled( $size) ) {
+			if ( Tiny_Image::is_original_unscaled( $size ) ) {
 				// unscaled is selected implicitly by original size
 				continue;
 			}

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -253,10 +253,13 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	/**
-	 * Retrieves image sizes as a map of size and width, height and tinify meta data
-	 * The first entry will always be '0', aka the original uploaded image.
+	 * Retrieves image sizes as a map of size and width, height and tinify meta data.
 	 *
-	 * @return array{string: array{width: int|null, height: int|null, tinify: array{}}} $sizes
+	 * The first entry will always be '0' (the original uploaded image), the second
+	 * will always be 'original_unscaled' (the unscaled copy WordPress stores for images
+	 * that exceed the big_image_size_threshold). Both entries share the same tinify setting.
+	 *
+	 * @return array<int|string, array{width: int|null, height: int|null, tinify: bool}>
 	 */
 	public function get_sizes() {
 		if ( is_array( $this->sizes ) ) {
@@ -265,13 +268,19 @@ class Tiny_Settings extends Tiny_WP_Base {
 
 		$setting = get_option( self::get_prefixed_name( 'sizes' ) );
 
-		$size        = Tiny_Image::ORIGINAL;
-		$this->sizes = array(
+		$size            = Tiny_Image::ORIGINAL;
+		$original_tinify = ! is_array( $setting ) ||
+			( isset( $setting[ $size ] ) && 'on' === $setting[ $size ] );
+		$this->sizes     = array(
 			$size => array(
 				'width'  => null,
 				'height' => null,
-				'tinify' => ! is_array( $setting ) ||
-					( isset( $setting[ $size ] ) && 'on' === $setting[ $size ] ),
+				'tinify' => $original_tinify,
+			),
+			Tiny_Image::ORIGINAL_UNSCALED => array(
+				'width'  => null,
+				'height' => null,
+				'tinify' => $original_tinify,
 			),
 		);
 
@@ -304,15 +313,6 @@ class Tiny_Settings extends Tiny_WP_Base {
 			if ( $values['tinify'] ) {
 				$this->tinify_sizes[] = $size;
 			}
-		}
-
-		/*
-			When the original is enabled, also include the unscaled original.
-			WordPress stores an unscaled copy of any uploaded image that exceeds
-			the big_image_size_threshold (default 2560 px). Images without such
-			a copy will simply skip this size in filter_image_sizes(). */
-		if ( in_array( Tiny_Image::ORIGINAL, $this->tinify_sizes, true ) ) {
-			$this->tinify_sizes[] = Tiny_Image::ORIGINAL_UNSCALED;
 		}
 
 		return $this->tinify_sizes;

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -568,6 +568,10 @@ class Tiny_Settings extends Tiny_WP_Base {
 			esc_attr( $dummy_size_name ) . '" value="on"/>';
 
 		foreach ( $this->get_sizes() as $size => $option ) {
+			if ( Tiny_Image::is_original_unscaled( $size) ) {
+				// unscaled is selected implicitly by original size
+				continue;
+			}
 			$this->render_size_checkboxes( $size, $option );
 		}
 		if ( self::wr2x_active() ) {

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -272,7 +272,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 		$original_tinify = ! is_array( $setting ) ||
 			( isset( $setting[ $size ] ) && 'on' === $setting[ $size ] );
 		$this->sizes     = array(
-			$size => array(
+			$size                         => array(
 				'width'  => null,
 				'height' => null,
 				'tinify' => $original_tinify,
@@ -363,7 +363,9 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function get_preserve_options( $size_name ) {
-		if ( ! Tiny_Image::is_original( $size_name ) && ! Tiny_Image::is_original_unscaled( $size_name ) ) {
+		if ( ! Tiny_Image::is_original( $size_name ) &&
+			! Tiny_Image::is_original_unscaled( $size_name )
+		) {
 			return false;
 		}
 		$options  = array();

--- a/src/class-tiny-settings.php
+++ b/src/class-tiny-settings.php
@@ -305,6 +305,16 @@ class Tiny_Settings extends Tiny_WP_Base {
 				$this->tinify_sizes[] = $size;
 			}
 		}
+
+		/*
+			When the original is enabled, also include the unscaled original.
+			WordPress stores an unscaled copy of any uploaded image that exceeds
+			the big_image_size_threshold (default 2560 px). Images without such
+			a copy will simply skip this size in filter_image_sizes(). */
+		if ( in_array( Tiny_Image::ORIGINAL, $this->tinify_sizes, true ) ) {
+			$this->tinify_sizes[] = Tiny_Image::ORIGINAL_UNSCALED;
+		}
+
 		return $this->tinify_sizes;
 	}
 
@@ -353,7 +363,7 @@ class Tiny_Settings extends Tiny_WP_Base {
 	}
 
 	public function get_preserve_options( $size_name ) {
-		if ( ! Tiny_Image::is_original( $size_name ) ) {
+		if ( ! Tiny_Image::is_original( $size_name ) && ! Tiny_Image::is_original_unscaled( $size_name ) ) {
 			return false;
 		}
 		$options  = array();

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -108,6 +108,7 @@ class WordPressStubs
 		$this->addMethod('esc_html_e');
 		$this->addMethod('esc_html');
 		$this->addMethod('maybe_unserialize');
+		$this->addMethod('wp_basename');
 		$this->defaults();
 		$this->create_filesystem();
 	}
@@ -531,6 +532,18 @@ class WordPressMocks
 	public function wp_json_encode($data, $options = 0, $depth = 512)
 	{
 		return json_encode($data, $options, $depth);
+	}
+
+	/**
+	 * Mocked function for https://developer.wordpress.org/reference/functions/wp_basename/
+	 *
+	 * @param string $path     File path.
+	 * @param string $suffix   Optional. If the filename ends in suffix, this will be cut. Default empty string.
+	 * @return string Trailing name component of the path.
+	 */
+	public function wp_basename($path, $suffix = '')
+	{
+		return urldecode(basename(str_replace(array('%2F', '%2f'), '/', urlencode($path)), $suffix));
 	}
 
 	/**

--- a/test/integration/settings.spec.ts
+++ b/test/integration/settings.spec.ts
@@ -181,13 +181,13 @@ test.describe('settings', () => {
 
     await page.locator('#submit').click();
 
-    await expect(page.getByText('With these settings you can compress at least 125 images for free each month.')).toBeVisible();
+    await expect(page.getByText('With these settings you can compress at least 100 images for free each month.')).toBeVisible();
   });
 
   test('update free compressions', async () => {
     await enableCompressionSizes(page, ['0', 'thumbnail', 'large'], false);
 
-    await expect(page.getByText('With these settings you can compress at least 166 images for free each month.')).toBeVisible();
+    await expect(page.getByText('With these settings you can compress at least 125 images for free each month.')).toBeVisible();
   });
 
   test('show no compressions', async () => {

--- a/test/unit/TinySettingsAdminTest.php
+++ b/test/unit/TinySettingsAdminTest.php
@@ -242,6 +242,26 @@ class Tiny_Settings_Admin_Test extends Tiny_TestCase {
 		);
 	}
 
+	public function test_get_active_tinify_sizes_includes_original_unscaled_when_original_is_active() {
+		$this->wp->addOption( 'tinypng_sizes', array( Tiny_Image::ORIGINAL => 'on' ) );
+
+		$sizes = $this->subject->get_active_tinify_sizes();
+
+		$this->assertContains( Tiny_Image::ORIGINAL, $sizes );
+		$this->assertContains( Tiny_Image::ORIGINAL_UNSCALED, $sizes );
+	}
+
+	public function test_get_active_tinify_sizes_excludes_original_unscaled_when_original_is_inactive() {
+		$this->wp->addOption( 'tinypng_sizes', array(
+			Tiny_Image::ORIGINAL => 'off',
+			'medium'             => 'on',
+		) );
+
+		$sizes = $this->subject->get_active_tinify_sizes();
+
+		$this->assertNotContains( Tiny_Image::ORIGINAL_UNSCALED, $sizes );
+	}
+
 	public function test_get_resize_enabled_should_return_true_if_enabled() {
 		$this->wp->addOption( 'tinypng_resize_original', array(
 			'enabled' => 'on',

--- a/test/unit/TinySettingsAdminTest.php
+++ b/test/unit/TinySettingsAdminTest.php
@@ -40,6 +40,11 @@ class Tiny_Settings_Admin_Test extends Tiny_TestCase {
 				'height' => null,
 				'tinify' => true,
 			),
+			Tiny_Image::ORIGINAL_UNSCALED => array(
+				'width' => null,
+				'height' => null,
+				'tinify' => true,
+			),
 			'thumbnail' => array(
 				'width' => 150,
 				'height' => 150,
@@ -96,6 +101,11 @@ class Tiny_Settings_Admin_Test extends Tiny_TestCase {
 				'height' => null,
 				'tinify' => true,
 			),
+			Tiny_Image::ORIGINAL_UNSCALED => array(
+				'width' => null,
+				'height' => null,
+				'tinify' => true,
+			),
 			'thumbnail' => array(
 				'width' => 150,
 				'height' => 150,
@@ -139,6 +149,11 @@ class Tiny_Settings_Admin_Test extends Tiny_TestCase {
 				'height' => null,
 				'tinify' => false,
 			),
+			Tiny_Image::ORIGINAL_UNSCALED => array(
+				'width' => null,
+				'height' => null,
+				'tinify' => false,
+			),
 			'thumbnail' => array(
 				'width' => 150,
 				'height' => 150,
@@ -166,6 +181,11 @@ class Tiny_Settings_Admin_Test extends Tiny_TestCase {
 		$this->subject->get_sizes();
 		$this->assertEquals(array(
 			0 => array(
+				'width' => null,
+				'height' => null,
+				'tinify' => true,
+			),
+			Tiny_Image::ORIGINAL_UNSCALED => array(
 				'width' => null,
 				'height' => null,
 				'tinify' => true,


### PR DESCRIPTION
WordPress scales down the original image when big_image_size_threshold is hit (defaults to 2560px). The scaled down version will be used when a user requests the `full` image and generates thumbnails using the unscaled version.

Users wanted to compress the unscaled original image as well as these might take up a lot of disk space.

**Changes**
- `src/class-tiny-image.php` when original image exists, will also add a Tiny_Image_Size for the unscaled version;
- `get_active_tinify_sizes` will return the unscaled size when original is enabled;
- `src/class-tiny-settings.php` will preserve meta data on the unscaled version if enabled;

**Considerations**
- When the original is enabled, it will now count as two compressions as the unscaled version will also account for one. I thought it was better to give an estimate to be on the safe side.
