### PR TITLE
pass ref_name as variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Verify version matches release tag
-      run: bin/check-version
+      run: bin/check-version ${{ github.ref_name }}
     - name: WordPress Plugin Deploy
       id: deploy
       uses: tinify/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Verify version matches release tag
-      run: bin/check-version ${{ github.ref_name }}
+      run: bin/check-version ${{ github.event.release.tag_name }}
     - name: WordPress Plugin Deploy
       id: deploy
       uses: tinify/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
Environment Variable GITHUB_REF was not avaiable when `bin/check-version` was run.

The GITHUB_REF should have been set:
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release

Reports indicating GITHUB_REF was empty:
https://github.com/orgs/community/discussions/64528

According to https://github.com/orgs/community/discussions/64528#discussioncomment-12978855, for release events, `github.event.release.tag_name` should contain the release tag and `github.ref_name` might not always provide the expected value.