### PR TITLE
Restore backup

### DIFF
--- a/docs/hooks/tiny_image_before_compression.md
+++ b/docs/hooks/tiny_image_before_compression.md
@@ -8,14 +8,22 @@ Action that runs before compressing an single attachment.
 ## Arguments
 
 1. `int        $attachment_id` - The attachment ID.
+2. `array|null $wp_metadata` - The attachment metadata.
+
+The metadata is passed along because WordPress has not necessarily stored it
+yet. On upload the compression runs from within
+`wp_generate_attachment_metadata`, so `wp_get_attachment_metadata()` can still
+be empty at this point. Use the passed metadata instead of looking it up.
 
 ## Example
 
 ```php
 add_action(
 	'tiny_image_before_compression',
-	function ( $id ) {
+	function ( $id, $wp_metadata ) {
 		// notify system of compression
-	}
+	},
+	10,
+	2
 );
 ```

--- a/src/class-tiny-diagnostics.php
+++ b/src/class-tiny-diagnostics.php
@@ -212,7 +212,7 @@ class Tiny_Diagnostics {
 				__( 'WordPress filesystem could not be initialized.', 'tiny-compress-images' )
 			);
 		}
-		$temp_dir      = trailingslashit( get_temp_dir() ) . 'tiny-compress-temp';
+		$temp_dir = trailingslashit( get_temp_dir() ) . 'tiny-compress-temp';
 		if ( ! $wp_filesystem->exists( $temp_dir ) ) {
 			wp_mkdir_p( $temp_dir );
 		}
@@ -256,7 +256,12 @@ class Tiny_Diagnostics {
 	public static function download_zip( $zip_path ) {
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
 		if ( false === $wp_filesystem ) {
-			wp_die( esc_html__( 'WordPress filesystem could not be initialized.', 'tiny-compress-images' ) );
+			wp_die(
+				esc_html__(
+					'WordPress filesystem could not be initialized.',
+					'tiny-compress-images'
+				)
+			);
 		}
 		if ( ! $wp_filesystem->exists( $zip_path ) ) {
 			wp_die( esc_html__( 'Diagnostic file not found.', 'tiny-compress-images' ) );

--- a/src/class-tiny-diagnostics.php
+++ b/src/class-tiny-diagnostics.php
@@ -206,6 +206,12 @@ class Tiny_Diagnostics {
 		}
 
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return new WP_Error(
+				'filesystem_unavailable',
+				__( 'WordPress filesystem could not be initialized.', 'tiny-compress-images' )
+			);
+		}
 		$temp_dir      = trailingslashit( get_temp_dir() ) . 'tiny-compress-temp';
 		if ( ! $wp_filesystem->exists( $temp_dir ) ) {
 			wp_mkdir_p( $temp_dir );
@@ -249,6 +255,9 @@ class Tiny_Diagnostics {
 	 */
 	public static function download_zip( $zip_path ) {
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			wp_die( esc_html__( 'WordPress filesystem could not be initialized.', 'tiny-compress-images' ) );
+		}
 		if ( ! $wp_filesystem->exists( $zip_path ) ) {
 			wp_die( esc_html__( 'Diagnostic file not found.', 'tiny-compress-images' ) );
 		}

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -130,9 +130,9 @@ class Tiny_Helpers {
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
-		WP_Filesystem();
+		$initialized = WP_Filesystem();
 
-		if ( ! ( $wp_filesystem instanceof WP_Filesystem_Base ) ) {
+		if ( true !== $initialized || ! ( $wp_filesystem instanceof WP_Filesystem_Base ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'Tiny Compress: Unable to initialize WordPress filesystem.' );
 			return false;

--- a/src/class-tiny-helpers.php
+++ b/src/class-tiny-helpers.php
@@ -115,12 +115,10 @@ class Tiny_Helpers {
 	 * Gets or initializes the WordPress filesystem instance.
 	 *
 	 * Returns the global WP_Filesystem instance, initializing it if necessary.
-	 * This helper prevents repeated initialization code throughout the plugin.
 	 *
 	 * @since 3.7.0
 	 *
-	 * @return WP_Filesystem_Base The WP_Filesystem instance.
-	 * @throws Exception If the filesystem cannot be initialized.
+	 * @return WP_Filesystem_Base|false The WP_Filesystem instance, or false on failure.
 	 */
 	public static function get_wp_filesystem() {
 		global $wp_filesystem;
@@ -129,14 +127,15 @@ class Tiny_Helpers {
 			return $wp_filesystem;
 		}
 
-		// Initialize the filesystem only if the function isn't available yet.
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 		WP_Filesystem();
 
 		if ( ! ( $wp_filesystem instanceof WP_Filesystem_Base ) ) {
-			throw new Exception( 'Unable to initialize WordPress filesystem.' );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'Tiny Compress: Unable to initialize WordPress filesystem.' );
+			return false;
 		}
 
 		return $wp_filesystem;

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -678,12 +678,12 @@ class Tiny_Image {
 
 	/**
 	 * Retrieves the original image of the Tiny_Image
-	 * 
+	 *
 	 *
 	 * @return Tiny_Image_Size|false the image or false if does not exist
 	 */
 	private function get_original_image() {
-		$original_image = $this->get_image_size( Tiny_Image::ORIGINAL_UNSCALED );
+		$original_image = $this->get_image_size( self::ORIGINAL_UNSCALED );
 		if ( null === $original_image ) {
 			$original_image = $this->get_image_size();
 		}
@@ -746,7 +746,7 @@ class Tiny_Image {
 		return $wp_filesystem->copy( $original_image->filename, $backup_file_path );
 	}
 
-	
+
 	/**
 	 * Retrieves the public URL of the backup of the original image.
 	 *
@@ -775,7 +775,7 @@ class Tiny_Image {
 	 * Restores the original image from its backup.
 	 *
 	 * - Copies the backup file over the current original
-	 * - clears compression metadata 
+	 * - clears compression metadata
 	 * - updates the WordPress attachment metadata
 	 *
 	 * @since 3.7.0

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -675,4 +675,99 @@ class Tiny_Image {
 
 		$this->update_tiny_post_meta();
 	}
+
+	/**
+	 * Retrieves the original image of the Tiny_Image
+	 * 
+	 *
+	 * @return Tiny_Image_Size|false the image or false if does not exist
+	 */
+	private function get_original_image() {
+		$original_image = $this->get_image_size( Tiny_Image::ORIGINAL_UNSCALED );
+		if ( null === $original_image ) {
+			$original_image = $this->get_image_size();
+		}
+
+		if ( null === $original_image ) {
+			return false;
+		}
+
+		return $original_image;
+	}
+
+	/**
+	 * Builds the filesystem path where the backup of the original image is
+	 * (or would be) stored.
+	 *
+	 * @return string|false the backup file path, or false if there is no original image
+	 */
+	private function get_backup_path() {
+		$original_image = $this->get_original_image();
+		if ( false === $original_image ) {
+			return false;
+		}
+
+		$file_path  = $original_image->filename;
+		$upload_dir = wp_upload_dir();
+		$basedir    = trailingslashit( $upload_dir['basedir'] );
+		if ( Tiny_Helpers::str_starts_with( $file_path, $basedir ) ) {
+			$file_path = substr( $file_path, strlen( $basedir ) );
+		}
+
+		return $basedir . 'tinify_backup/' . $file_path;
+	}
+
+	/**
+	 * Creates a backup copy of the original image, if one does not already exist.
+	 *
+	 * @return bool true on success, false on failure or if a backup already exists
+	 */
+	public function create_backup() {
+
+		$backup_file_path = $this->get_backup_path();
+		if ( false === $backup_file_path ) {
+			return false;
+		}
+
+		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+
+		if ( $wp_filesystem->exists( $backup_file_path ) ) {
+			return false;
+		}
+
+		$backup_dir = dirname( $backup_file_path );
+
+		if ( ! wp_mkdir_p( $backup_dir ) ) {
+			return false;
+		}
+
+		$original_image = $this->get_original_image();
+
+		return $wp_filesystem->copy( $original_image->filename, $backup_file_path );
+	}
+
+	
+	/**
+	 * Retrieves the public URL of the backup of the original image.
+	 *
+	 * @return string|false the backup URL, or false if no backup exists
+	 */
+	public function get_backup() {
+		$backup_file_path = $this->get_backup_path();
+		if ( false === $backup_file_path ) {
+			return false;
+		}
+
+		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+
+		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
+			return false;
+		}
+
+		$upload_dir = wp_upload_dir();
+		$basedir    = trailingslashit( $upload_dir['basedir'] );
+		$baseurl    = trailingslashit( $upload_dir['baseurl'] );
+
+		return str_replace( $basedir, $baseurl, $backup_file_path );
+	}
 }

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -770,4 +770,57 @@ class Tiny_Image {
 
 		return str_replace( $basedir, $baseurl, $backup_file_path );
 	}
+
+	/**
+	 * Restores the original image from its backup.
+	 *
+	 * - Copies the backup file over the current original
+	 * - clears compression metadata 
+	 * - updates the WordPress attachment metadata
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return bool True on success, false if no backup exists or the copy fails.
+	 */
+	public function restore_backup() {
+		$backup_file_path = $this->get_backup_path();
+		if ( false === $backup_file_path ) {
+			return false;
+		}
+
+		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+
+		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
+			return false;
+		}
+
+		$original_size_key = null !== $this->get_image_size( self::ORIGINAL_UNSCALED )
+			? self::ORIGINAL_UNSCALED
+			: self::ORIGINAL;
+
+		$original_image = $this->get_image_size( $original_size_key );
+		if ( null === $original_image ) {
+			return false;
+		}
+
+		if ( ! $wp_filesystem->copy( $backup_file_path, $original_image->filename, true ) ) {
+			return false;
+		}
+
+		$original_image->meta = array();
+		$this->update_tiny_post_meta();
+
+		// only on non-unscaled, as resize can be turned on
+		if ( self::is_original( $original_size_key ) ) {
+			$image_size = wp_getimagesize( $original_image->filename );
+			if ( $image_size ) {
+				$this->wp_metadata['width']    = $image_size[0];
+				$this->wp_metadata['height']   = $image_size[1];
+				$this->wp_metadata['filesize'] = filesize( $original_image->filename );
+				wp_update_attachment_metadata( $this->id, $this->wp_metadata );
+			}
+		}
+
+		return true;
+	}
 }

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -774,9 +774,10 @@ class Tiny_Image {
 	/**
 	 * Restores the original image from its backup.
 	 *
-	 * - Copies the backup file over the current original
-	 * - clears compression metadata
-	 * - updates the WordPress attachment metadata
+	 * - Copies the backup file over the current original.
+	 * - Clears compression metadata for all image sizes.
+	 * - Regenerates all thumbnail sizes from the restored image.
+	 * - Updates the WordPress attachment metadata.
 	 *
 	 * @since 3.7.0
 	 *
@@ -807,20 +808,41 @@ class Tiny_Image {
 			return false;
 		}
 
-		$original_image->meta = array();
+		// Clear compression metadata for all image sizes.
+		foreach ( $this->sizes as $size ) {
+			$size->meta = array();
+		}
 		$this->update_tiny_post_meta();
 
-		// only on non-unscaled, as resize can be turned on
-		if ( self::is_original( $original_size_key ) ) {
-			$image_size = wp_getimagesize( $original_image->filename );
-			if ( $image_size ) {
-				$this->wp_metadata['width']    = $image_size[0];
-				$this->wp_metadata['height']   = $image_size[1];
-				$this->wp_metadata['filesize'] = filesize( $original_image->filename );
-				wp_update_attachment_metadata( $this->id, $this->wp_metadata );
-			}
+		// Regenerate all thumbnail sizes from the restored image.
+		$new_metadata = wp_generate_attachment_metadata( $this->id, $original_image->filename );
+		if ( $new_metadata ) {
+			$this->wp_metadata = $new_metadata;
+			wp_update_attachment_metadata( $this->id, $this->wp_metadata );
 		}
 
 		return true;
+	}
+
+	/**
+	 * Deletes the backup file of the original image, if it exists.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return bool True on success or if no backup exists, false on deletion failure.
+	 */
+	public function delete_backup() {
+		$backup_file_path = $this->get_backup_path();
+		if ( false === $backup_file_path ) {
+			return true;
+		}
+
+		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+
+		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
+			return true;
+		}
+
+		return $wp_filesystem->delete( $backup_file_path );
 	}
 }

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -778,6 +778,29 @@ class Tiny_Image {
 	}
 
 	/**
+	 * Regenerates all thumbnail sizes of an attachment from a file.
+	 *
+	 * Uses wp_create_image_subsizes() when available, which does not apply
+	 * the `wp_generate_attachment_metadata` filter. That filter is what starts
+	 * a compression and the image that has just been restored should be left alone.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @param string $filename Absolute path of the image to regenerate from.
+	 * @return array The regenerated attachment metadata.
+	 */
+	private function regenerate_sizes( $filename ) {
+		// https://developer.wordpress.org/reference/functions/wp_create_image_subsizes/
+		if ( function_exists( 'wp_create_image_subsizes' ) ) {
+			return wp_create_image_subsizes( $filename, $this->id );
+		}
+
+		// WordPress < 5.3.
+		// https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/
+		return wp_generate_attachment_metadata( $this->id, $filename );
+	}
+
+	/**
 	 * Restores the original image from its backup.
 	 *
 	 * - Copies the backup file over the current original.
@@ -820,8 +843,7 @@ class Tiny_Image {
 		$this->update_tiny_post_meta();
 
 		// Regenerate all thumbnail sizes from the restored image.
-		// https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/
-		$new_metadata = wp_generate_attachment_metadata( $this->id, $original_image->filename );
+		$new_metadata = $this->regenerate_sizes( $original_image->filename );
 		if ( $new_metadata ) {
 			$this->wp_metadata = $new_metadata;
 			wp_update_attachment_metadata( $this->id, $this->wp_metadata );

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -820,6 +820,7 @@ class Tiny_Image {
 		$this->update_tiny_post_meta();
 
 		// Regenerate all thumbnail sizes from the restored image.
+		// https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/
 		$new_metadata = wp_generate_attachment_metadata( $this->id, $original_image->filename );
 		if ( $new_metadata ) {
 			$this->wp_metadata = $new_metadata;

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -804,12 +804,8 @@ class Tiny_Image {
 			return false;
 		}
 
-		$original_size_key = null !== $this->get_image_size( self::ORIGINAL_UNSCALED )
-			? self::ORIGINAL_UNSCALED
-			: self::ORIGINAL;
-
-		$original_image = $this->get_image_size( $original_size_key );
-		if ( null === $original_image ) {
+		$original_image = $this->get_original_image();
+		if ( false === $original_image ) {
 			return false;
 		}
 
@@ -828,6 +824,8 @@ class Tiny_Image {
 		if ( $new_metadata ) {
 			$this->wp_metadata = $new_metadata;
 			wp_update_attachment_metadata( $this->id, $this->wp_metadata );
+			$this->sizes = array();
+			$this->parse_wp_metadata();
 		}
 
 		return true;

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -234,13 +234,19 @@ class Tiny_Image {
 		/**
 		 * Fires before an image is sent for compression.
 		 *
+		 * The metadata is passed along because it has not necessarily been
+		 * stored yet. On upload the compression runs from within
+		 * `wp_generate_attachment_metadata`, before WordPress saves it.
+		 *
 		 * @since 3.7.0
 		 *
-		 * @param int $attachment_id The attachment ID
+		 * @param int   $attachment_id The attachment ID
+		 * @param array $wp_metadata   The attachment metadata
 		 */
 		do_action(
 			'tiny_image_before_compression',
-			$this->id
+			$this->id,
+			$this->wp_metadata
 		);
 
 		$success = 0;

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -730,6 +730,9 @@ class Tiny_Image {
 		}
 
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return false;
+		}
 
 		if ( $wp_filesystem->exists( $backup_file_path ) ) {
 			return false;
@@ -759,6 +762,9 @@ class Tiny_Image {
 		}
 
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return false;
+		}
 
 		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
 			return false;
@@ -790,6 +796,9 @@ class Tiny_Image {
 		}
 
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return false;
+		}
 
 		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
 			return false;
@@ -838,6 +847,9 @@ class Tiny_Image {
 		}
 
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return false;
+		}
 
 		if ( ! $wp_filesystem->exists( $backup_file_path ) ) {
 			return true;

--- a/src/class-tiny-image.php
+++ b/src/class-tiny-image.php
@@ -801,9 +801,26 @@ class Tiny_Image {
 			return wp_create_image_subsizes( $filename, $this->id );
 		}
 
-		// WordPress < 5.3.
+		/*
+		WordPress < 5.3 has no way of regenerating the sizes without applying
+			the filter, so it is disabled for the duration of the call. */
+		global $tiny_plugin;
+		$compress_on_upload = ( $tiny_plugin instanceof Tiny_Plugin )
+			? array( $tiny_plugin, 'process_attachment' )
+			: null;
+
+		if ( $compress_on_upload ) {
+			remove_filter( 'wp_generate_attachment_metadata', $compress_on_upload, 10 );
+		}
+
 		// https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/
-		return wp_generate_attachment_metadata( $this->id, $filename );
+		$metadata = wp_generate_attachment_metadata( $this->id, $filename );
+
+		if ( $compress_on_upload ) {
+			add_filter( 'wp_generate_attachment_metadata', $compress_on_upload, 10, 2 );
+		}
+
+		return $metadata;
 	}
 
 	/**

--- a/src/class-tiny-logger.php
+++ b/src/class-tiny-logger.php
@@ -231,7 +231,7 @@ class Tiny_Logger {
 		if ( false === $wp_filesystem ) {
 			return false;
 		}
-		$file_exits    = $wp_filesystem->exists( $log_path );
+		$file_exits = $wp_filesystem->exists( $log_path );
 		if ( $file_exits ) {
 			return $wp_filesystem->delete( $log_path );
 		}

--- a/src/class-tiny-logger.php
+++ b/src/class-tiny-logger.php
@@ -179,6 +179,9 @@ class Tiny_Logger {
 		// Ensure log directory exists.
 		$log_dir       = dirname( $this->log_file_path );
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return;
+		}
 		if ( ! $wp_filesystem->exists( $log_dir ) ) {
 			wp_mkdir_p( $log_dir );
 			self::create_blocking_files( $log_dir );
@@ -201,6 +204,9 @@ class Tiny_Logger {
 	 */
 	private function rotate_logs() {
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return;
+		}
 		if ( ! $wp_filesystem->exists( $this->log_file_path ) ) {
 			return;
 		}
@@ -222,6 +228,9 @@ class Tiny_Logger {
 		$instance      = self::get_instance();
 		$log_path      = $instance->get_log_file_path();
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return false;
+		}
 		$file_exits    = $wp_filesystem->exists( $log_path );
 		if ( $file_exits ) {
 			return $wp_filesystem->delete( $log_path );
@@ -239,6 +248,9 @@ class Tiny_Logger {
 	 */
 	private static function create_blocking_files( $log_dir ) {
 		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
+		if ( false === $wp_filesystem ) {
+			return;
+		}
 
 		$index_file = trailingslashit( $log_dir ) . 'index.html';
 		if ( ! $wp_filesystem->exists( $index_file ) ) {

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -984,7 +984,11 @@ class Tiny_Plugin extends Tiny_WP_Base {
 
 		list($id, $metadata) = $response['data'];
 		$tiny_image          = new Tiny_Image( $this->settings, $id, $metadata );
-		$tiny_image->restore_backup();
+
+		if ( ! $tiny_image->restore_backup() ) {
+			echo esc_html__( 'Could not restore backup. The backup file may not exist or could not be written.', 'tiny-compress-images' );
+			exit();
+		}
 
 		$this->render_compress_details( $tiny_image );
 

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -934,37 +934,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 
 		$tiny_image = new Tiny_Image( $this->settings, $attachment_id );
 
-		$original_image = $tiny_image->get_image_size( Tiny_Image::ORIGINAL_UNSCALED );
-		if ( null === $original_image ) {
-			$original_image = $tiny_image->get_image_size();
-		}
-
-		if ( null === $original_image ) {
-			return false;
-		}
-
-		$file_path  = $original_image->filename;
-		$upload_dir = wp_upload_dir();
-		$basedir    = trailingslashit( $upload_dir['basedir'] );
-		if ( Tiny_Helpers::str_starts_with( $file_path, $basedir ) ) {
-			$file_path = substr( $file_path, strlen( $basedir ) );
-		}
-
-		$backup_file = $basedir . 'tinify_backup/' . $file_path;
-
-		$wp_filesystem = Tiny_Helpers::get_wp_filesystem();
-
-		if ( $wp_filesystem->exists( $backup_file ) ) {
-			return false;
-		}
-
-		$backup_dir = dirname( $backup_file );
-
-		if ( ! wp_mkdir_p( $backup_dir ) ) {
-			return false;
-		}
-
-		return $wp_filesystem->copy( $original_image->filename, $backup_file );
+		return $tiny_image->create_backup();
 	}
 
 	public static function request_review() {

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -119,6 +119,11 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			$this->get_method( 'mark_image_as_compressed' )
 		);
 
+		add_action(
+			'wp_ajax_tiny_restore_backup',
+			$this->get_method( 'restore_backup_image' )
+		);
+
 		/*
 		When touching any functionality linked to image compressions when
 			uploading images make sure it also works with XML-RPC. See README. */
@@ -957,6 +962,32 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	 */
 	public static function uninstall() {
 		Tiny_Apache_Rewrite::uninstall_rules();
+	}
+
+	/**
+	 * Restores the original image from its backup via AJAX.
+	 *
+	 * Validates the request, calls restore_backup() on the image, then
+	 * re-renders the compression details partial in the response.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @return void
+	 */
+	public function restore_backup_image() {
+		$response = $this->validate_ajax_attachment_request();
+		if ( isset( $response['error'] ) ) {
+			echo esc_html( $response['error'] );
+			exit();
+		}
+
+		list($id, $metadata) = $response['data'];
+		$tiny_image          = new Tiny_Image( $this->settings, $id, $metadata );
+		$tiny_image->restore_backup();
+
+		$this->render_compress_details( $tiny_image );
+
+		exit();
 	}
 
 	public function mark_image_as_compressed() {

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -914,6 +914,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	public function clean_attachment( $post_id ) {
 		$tiny_image = new Tiny_Image( $this->settings, $post_id );
 		$tiny_image->delete_converted_image();
+		$tiny_image->delete_backup();
 	}
 
 	/**

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -751,7 +751,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		if ( self::MEDIA_COLUMN === $column ) {
 			$tiny_image = new Tiny_Image( $this->settings, $id );
 			if ( $tiny_image->file_type_allowed() ) {
-				echo '<div class="tiny-ajax-container">';
+				echo '<div class="tiny-ajax-container" data-tiny-media-id="' . absint($id) . '">';
 				$this->render_compress_details( $tiny_image );
 				echo '</div>';
 			}
@@ -766,7 +766,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			echo '<h4>';
 			esc_html_e( 'JPEG, PNG, & WebP optimization', 'tiny-compress-images' );
 			echo '</h4>';
-			echo '<div class="tiny-ajax-container">';
+			echo '<div class="tiny-ajax-container" data-tiny-media-id="' . absint($post->ID) . '">';
 			$this->render_compress_details( $tiny_image );
 			echo '</div>';
 			echo '</div>';

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -72,7 +72,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			'tiny_image_before_compression',
 			$this->get_method( 'backup_original_image' ),
 			10,
-			1
+			2
 		);
 
 		load_plugin_textdomain(
@@ -934,12 +934,12 @@ class Tiny_Plugin extends Tiny_WP_Base {
 	 * @param int       $attachment_id The ID of the attachment
 	 * @return bool             return true on backup created
 	 */
-	public function backup_original_image( $attachment_id ) {
+	public function backup_original_image( $attachment_id, $wp_metadata = null ) {
 		if ( ! $this->settings->get_backup_enabled() ) {
 			return false;
 		}
 
-		$tiny_image = new Tiny_Image( $this->settings, $attachment_id );
+		$tiny_image = new Tiny_Image( $this->settings, $attachment_id, $wp_metadata );
 
 		return $tiny_image->create_backup();
 	}

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -751,7 +751,7 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		if ( self::MEDIA_COLUMN === $column ) {
 			$tiny_image = new Tiny_Image( $this->settings, $id );
 			if ( $tiny_image->file_type_allowed() ) {
-				echo '<div class="tiny-ajax-container" data-tiny-media-id="' . absint($id) . '">';
+				echo '<div class="tiny-ajax-container" data-tiny-media-id="' . absint( $id ) . '">';
 				$this->render_compress_details( $tiny_image );
 				echo '</div>';
 			}
@@ -766,7 +766,8 @@ class Tiny_Plugin extends Tiny_WP_Base {
 			echo '<h4>';
 			esc_html_e( 'JPEG, PNG, & WebP optimization', 'tiny-compress-images' );
 			echo '</h4>';
-			echo '<div class="tiny-ajax-container" data-tiny-media-id="' . absint($post->ID) . '">';
+			echo '<div class="tiny-ajax-container" data-tiny-media-id="';
+			echo absint( $post->ID ) . '">';
 			$this->render_compress_details( $tiny_image );
 			echo '</div>';
 			echo '</div>';
@@ -986,7 +987,10 @@ class Tiny_Plugin extends Tiny_WP_Base {
 		$tiny_image          = new Tiny_Image( $this->settings, $id, $metadata );
 
 		if ( ! $tiny_image->restore_backup() ) {
-			echo esc_html__( 'Could not restore backup. The backup file may not exist or could not be written.', 'tiny-compress-images' );
+			echo esc_html__(
+				'Could not restore backup. The backup file may not exist or could not be written.',
+				'tiny-compress-images'
+			);
 			exit();
 		}
 

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -412,7 +412,7 @@ input[type=number][name*="tinypng_resize_original"] {
 }
 
 .tiny-compression-details {
-	padding: 10px;
+	padding: 10px 0;
 }
 
 .tiny-compression-details table {

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -482,3 +482,16 @@ fieldset.tinypng_convert_fields[disabled] {
 .tiny-mt-2 {
 	margin-top: 10px;
 }
+
+.tiny-dialog {
+	padding: 20px;
+	border: 1px solid #ccd0d4;
+	border-radius: 4px;
+	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
+}
+
+.tiny-dialog-actions {
+	display: flex;
+	gap: 10px;
+	justify-content: flex-end;
+}

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -521,5 +521,5 @@ fieldset.tinypng_convert_fields[disabled] {
 
 .tiny-icon-backup {
 	flex-shrink: 0;
-	fill: currentColor;
+	fill: currentcolor;
 }

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -499,3 +499,27 @@ fieldset.tinypng_convert_fields[disabled] {
 	gap: 10px;
 	justify-content: flex-end;
 }
+
+.tiny-dialog-title {
+	font-size: 1.3rem;
+}
+
+.tiny-compression-details .tiny-card {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 5px 20px;
+	background: #F1F7FF;
+	border: 1px solid #e1e1e1;
+}
+
+.tiny-card a.button {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.tiny-icon-backup {
+	flex-shrink: 0;
+	fill: currentColor;
+}

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -490,6 +490,10 @@ fieldset.tinypng_convert_fields[disabled] {
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
 }
 
+.tiny-dialog-error {
+	color: #dc3232;
+}
+
 .tiny-dialog-actions {
 	display: flex;
 	gap: 10px;

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -1,4 +1,48 @@
-(function() {
+(function () {
+  function restoreBackup(attachmentId, container) {
+    jQuery.ajax({
+      url: ajaxurl,
+      type: 'POST',
+      data: {
+        _nonce: tinyCompress.nonce,
+        action: 'tiny_restore_backup',
+        id: attachmentId,
+      },
+      success: function (data) {
+        container.html(data);
+      },
+    });
+  }
+
+  jQuery(document).on('click', 'a[data-dialog-id]', function (e) {
+    e.preventDefault();
+    const trigger = jQuery(e.currentTarget);
+    const dialogID = trigger.data('dialog-id');
+    if (!dialogID) {
+      return;
+    }
+
+    const dialog = document.getElementById(dialogID);
+    if (!dialog) {
+      return;
+    }
+
+    const attachmentId = trigger.data('id');
+    const container = jQuery('#modal_' + attachmentId).closest('.tiny-ajax-container');
+
+    dialog.showModal();
+
+    dialog.addEventListener('close', function onClose() {
+      dialog.removeEventListener('close', onClose);
+      if (dialog.returnValue === 'confirm') {
+        if (typeof tb_remove === 'function') {
+          tb_remove();
+        }
+        restoreBackup(attachmentId, container);
+      }
+    });
+  });
+
   function downloadDiagnostics() {
     try {
       jQuery('#download-diagnostics-spinner').show();

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -1,5 +1,6 @@
 (function () {
   function restoreBackup(attachmentId, container) {
+    container.css('opacity', '0.5');
     jQuery.ajax({
       url: ajaxurl,
       type: 'POST',
@@ -9,7 +10,13 @@
         id: attachmentId,
       },
       success: function (data) {
+        container.css('opacity', '1');
         container.html(data);
+      },
+      error: function () {
+        container.css('opacity', '1');
+        // TODO: Replace when actual message
+        container.html('<p>Could not restore backup. Please try again.</p>');
       },
     });
   }

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -39,12 +39,8 @@
 
     dialog.showModal();
 
-    dialog.addEventListener('close', function onClose() {
-      dialog.removeEventListener('close', onClose);
-      if (dialog.returnValue === 'confirm') {
-        if (typeof tb_remove === 'function') {
-          tb_remove();
-        }
+    dialog.addEventListener('close', () => {
+      if (dialog.returnValue === 'submit') {
         restoreBackup(attachmentId, container);
       }
     });

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -38,6 +38,14 @@
         }
         const result = await restoreBackup(attachmentId);
         dialog.close();
+
+        // refresh thickbox
+        const modal = container.querySelector('.modal');
+        const ajaxContent = document.getElementById('TB_ajaxContent');
+        if (modal && ajaxContent) {
+          modal.append(...ajaxContent.children);
+        }
+
         container.innerHTML = result;
         if (typeof tb_remove === 'function') {
           tb_remove();

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -26,42 +26,44 @@
 
     const attachmentId = trigger.data('id');
     const container = document.querySelector(`[data-tiny-media-id="${attachmentId}"]`);
+    const confirmButton = dialog.querySelector('button[value="submit"]');
 
     dialog.showModal();
 
-    dialog.addEventListener('cancel', async (e) => {
-      e.preventDefault();
-      const spinner = dialog.querySelector('.spinner');
-      try {
-        if (spinner) {
-          spinner.style.visibility = 'visible';
-        }
-        const result = await restoreBackup(attachmentId);
-        dialog.close();
+    if (confirmButton) {
+      confirmButton.onclick = async () => {
+        const spinner = dialog.querySelector('.spinner');
+        try {
+          if (spinner) {
+            spinner.style.visibility = 'visible';
+          }
+          const result = await restoreBackup(attachmentId);
+          dialog.close();
 
-        // refresh thickbox
-        const modal = container.querySelector('.modal');
-        const ajaxContent = document.getElementById('TB_ajaxContent');
-        if (modal && ajaxContent) {
-          modal.append(...ajaxContent.children);
-        }
+          // refresh thickbox
+          const modal = container.querySelector('.modal');
+          const ajaxContent = document.getElementById('TB_ajaxContent');
+          if (modal && ajaxContent) {
+            modal.append(...ajaxContent.children);
+          }
 
-        container.innerHTML = result;
-        if (typeof tb_remove === 'function') {
-          tb_remove();
+          container.innerHTML = result;
+          if (typeof tb_remove === 'function') {
+            tb_remove();
+          }
+        } catch (err) {
+          const errorEl = dialog.querySelector('.tiny-dialog-error');
+          if (errorEl) {
+            errorEl.textContent = err.responseText || 'Failed to restore backup.';
+            errorEl.hidden = false;
+          }
+        } finally {
+          if (spinner) {
+            spinner.style.visibility = 'hidden';
+          }
         }
-      } catch (err) {
-        const errorEl = dialog.querySelector('.tiny-dialog-error');
-        if (errorEl) {
-          errorEl.textContent = err.responseText || 'Failed to restore backup.';
-          errorEl.hidden = false;
-        }
-      } finally {
-        if (spinner) {
-          spinner.style.visibility = 'hidden';
-        }
-      }
-    }, { once: true });
+      };
+    }
   });
 
   function downloadDiagnostics() {

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -37,18 +37,23 @@
           spinner.style.visibility = 'visible';
         }
         const result = await restoreBackup(attachmentId);
+        dialog.close();
         container.innerHTML = result;
         if (typeof tb_remove === 'function') {
           tb_remove();
         }
       } catch (err) {
-        console.log('err:', err);
+        const errorEl = dialog.querySelector('.tiny-dialog-error');
+        if (errorEl) {
+          errorEl.textContent = err.responseText || 'Failed to restore backup.';
+          errorEl.hidden = false;
+        }
       } finally {
         if (spinner) {
           spinner.style.visibility = 'hidden';
         }
       }
-    });
+    }, { once: true });
   });
 
   function downloadDiagnostics() {

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -31,8 +31,16 @@
     dialog.showModal();
 
     if (confirmButton) {
+      let restoring = false;
       confirmButton.onclick = async () => {
+        if (restoring) {
+          return;
+        }
+        restoring = true;
+        confirmButton.disabled = true;
+
         const spinner = dialog.querySelector('.spinner');
+        let allowRetry = false;
         try {
           if (spinner) {
             spinner.style.visibility = 'visible';
@@ -52,12 +60,17 @@
             tb_remove();
           }
         } catch (err) {
+          allowRetry = true;
           const errorEl = dialog.querySelector('.tiny-dialog-error');
           if (errorEl) {
             errorEl.textContent = err.responseText || 'Failed to restore backup.';
             errorEl.hidden = false;
           }
         } finally {
+          restoring = false;
+          if (allowRetry) {
+            confirmButton.disabled = false;
+          }
           if (spinner) {
             spinner.style.visibility = 'hidden';
           }

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -1,22 +1,12 @@
 (function () {
-  function restoreBackup(attachmentId, container) {
-    container.css('opacity', '0.5');
-    jQuery.ajax({
+  async function restoreBackup(attachmentId) {
+    return jQuery.ajax({
       url: ajaxurl,
       type: 'POST',
       data: {
         _nonce: tinyCompress.nonce,
         action: 'tiny_restore_backup',
         id: attachmentId,
-      },
-      success: function (data) {
-        container.css('opacity', '1');
-        container.html(data);
-      },
-      error: function () {
-        container.css('opacity', '1');
-        // TODO: Replace when actual message
-        container.html('<p>Could not restore backup. Please try again.</p>');
       },
     });
   }
@@ -35,13 +25,28 @@
     }
 
     const attachmentId = trigger.data('id');
-    const container = jQuery('#modal_' + attachmentId).closest('.tiny-ajax-container');
+    const container = document.querySelector(`[data-tiny-media-id="${attachmentId}"]`);
 
     dialog.showModal();
 
-    dialog.addEventListener('close', () => {
-      if (dialog.returnValue === 'submit') {
-        restoreBackup(attachmentId, container);
+    dialog.addEventListener('cancel', async (e) => {
+      e.preventDefault();
+      const spinner = dialog.querySelector('.spinner');
+      try {
+        if (spinner) {
+          spinner.style.visibility = 'visible';
+        }
+        const result = await restoreBackup(attachmentId);
+        container.innerHTML = result;
+        if (typeof tb_remove === 'function') {
+          tb_remove();
+        }
+      } catch (err) {
+        console.log('err:', err);
+      } finally {
+        if (spinner) {
+          spinner.style.visibility = 'hidden';
+        }
       }
     });
   });

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Details on the backup of the image
+ *
+ * @var Tiny_Plugin $this               The plugin instance.
+ * @var Tiny_Image  $tiny_image         The image being compressed.
+ * @var int[]       $images_to_compress The IDs that are being compressed
+ */
+
+$available_sizes              = array_keys( $this->settings->get_sizes() );
+$conversion_enabled           = $this->settings->get_conversion_enabled();
+$active_sizes                 = $this->settings->get_sizes();
+$backup_enabled				  = $this->settings->get_backup_enabled();
+$active_tinify_sizes          = $this->settings->get_active_tinify_sizes();
+$error                        = $tiny_image->get_latest_error();
+$total                        = $tiny_image->get_count( array( 'modified', 'missing', 'has_been_compressed', 'compressed', 'has_been_converted' ) );
+$active                       = $tiny_image->get_count( array( 'uncompressed', 'never_compressed', 'unconverted' ), $active_tinify_sizes );
+$image_statistics             = $tiny_image->get_statistics( $active_sizes, $active_tinify_sizes );
+$available_uncompressed_sizes = $image_statistics['available_uncompressed_sizes'];
+$size_before                  = $image_statistics['initial_total_size'];
+$size_after                   = $image_statistics['compressed_total_size'];
+
+$size_active = array_fill_keys( $active_tinify_sizes, true );
+$size_exists = array_fill_keys( $available_sizes, true );
+ksort( $size_exists );
+
+?>
+<?php if ($backup_enabled) {
+	$backup = $tiny_image->get_backup();
+?>
+	<p>
+		<?php if ($backup) { ?>
+			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
+				<?php esc_html_e('View Uncompressed'); ?>
+			</a>
+			<a href="">
+				<?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?>
+			</a>
+		<?php } else { ?>
+			<span>
+				<?php esc_html_e('No backup available', 'tiny-compress-images'); ?>
+			</span>
+		<?php } ?>
+	</p>
+<?php } ?>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -27,15 +27,28 @@ ksort( $size_exists );
 ?>
 <?php if ($backup_enabled) {
 	$backup = $tiny_image->get_backup();
+	$modal_id = "modal_" . absint( $tiny_image->get_id() ) . "_backup";
 ?>
 	<p>
 		<?php if ($backup) { ?>
 			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
 				<?php esc_html_e('View Uncompressed'); ?>
 			</a>
-			<a href="">
+			<a href="#" data-dialog-id="<?php echo esc_attr($modal_id); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
 				<?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?>
 			</a>
+			<dialog id="<?php echo esc_attr($modal_id); ?>" class="tiny-dialog">
+				<p><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></p>
+				
+				<form method="dialog" class="tiny-dialog-actions">
+					<button value="cancel" class="button">
+						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
+					</button>
+					<button value="confirm" class="button button-primary">
+						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
+					</button>
+				</form>
+			</dialog>
 		<?php } else { ?>
 			<span>
 				<?php esc_html_e('No backup available', 'tiny-compress-images'); ?>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -2,27 +2,11 @@
 /**
  * Details on the backup of the image
  *
- * @var Tiny_Plugin $this               The plugin instance.
- * @var Tiny_Image  $tiny_image         The image being compressed.
- * @var int[]       $images_to_compress The IDs that are being compressed
+ * @var Tiny_Plugin $this       The plugin instance.
+ * @var Tiny_Image  $tiny_image The image being compressed.
  */
 
-$available_sizes              = array_keys( $this->settings->get_sizes() );
-$conversion_enabled           = $this->settings->get_conversion_enabled();
-$active_sizes                 = $this->settings->get_sizes();
-$backup_enabled               = $this->settings->get_backup_enabled();
-$active_tinify_sizes          = $this->settings->get_active_tinify_sizes();
-$error                        = $tiny_image->get_latest_error();
-$total                        = $tiny_image->get_count( array( 'modified', 'missing', 'has_been_compressed', 'compressed', 'has_been_converted' ) );
-$active                       = $tiny_image->get_count( array( 'uncompressed', 'never_compressed', 'unconverted' ), $active_tinify_sizes );
-$image_statistics             = $tiny_image->get_statistics( $active_sizes, $active_tinify_sizes );
-$available_uncompressed_sizes = $image_statistics['available_uncompressed_sizes'];
-$size_before                  = $image_statistics['initial_total_size'];
-$size_after                   = $image_statistics['compressed_total_size'];
-
-$size_active = array_fill_keys( $active_tinify_sizes, true );
-$size_exists = array_fill_keys( $available_sizes, true );
-ksort( $size_exists );
+$backup_enabled = $this->settings->get_backup_enabled();
 
 ?>
 <?php

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -10,7 +10,7 @@
 $available_sizes              = array_keys( $this->settings->get_sizes() );
 $conversion_enabled           = $this->settings->get_conversion_enabled();
 $active_sizes                 = $this->settings->get_sizes();
-$backup_enabled				  = $this->settings->get_backup_enabled();
+$backup_enabled               = $this->settings->get_backup_enabled();
 $active_tinify_sizes          = $this->settings->get_active_tinify_sizes();
 $error                        = $tiny_image->get_latest_error();
 $total                        = $tiny_image->get_count( array( 'modified', 'missing', 'has_been_compressed', 'compressed', 'has_been_converted' ) );
@@ -25,19 +25,20 @@ $size_exists = array_fill_keys( $available_sizes, true );
 ksort( $size_exists );
 
 ?>
-<?php if ($backup_enabled) {
-	$backup = $tiny_image->get_backup();
-	$modal_id = "modal_" . absint( $tiny_image->get_id() ) . "_backup";
-?>
+<?php
+if ( $backup_enabled ) {
+	$backup   = $tiny_image->get_backup();
+	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
+	?>
 	<p>
-		<?php if ($backup) { ?>
+		<?php if ( $backup ) { ?>
 			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
-				<?php esc_html_e('View Uncompressed'); ?>
+				<?php esc_html_e( 'View Uncompressed' ); ?>
 			</a>
-			<a href="#" data-dialog-id="<?php echo esc_attr($modal_id); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
-				<?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?>
+			<a href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
+				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
 			</a>
-			<dialog id="<?php echo esc_attr($modal_id); ?>" class="tiny-dialog">
+			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
 				<p><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></p>
 				
 				<form method="dialog" class="tiny-dialog-actions">
@@ -51,7 +52,7 @@ ksort( $size_exists );
 			</dialog>
 		<?php } else { ?>
 			<span>
-				<?php esc_html_e('No backup available', 'tiny-compress-images'); ?>
+				<?php esc_html_e( 'No backup available', 'tiny-compress-images' ); ?>
 			</span>
 		<?php } ?>
 	</p>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -16,7 +16,7 @@ if ( $backup_enabled ) {
 	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
 	?>
 	<?php if ( $backup ) { ?>
-		<p><?php echo esc_html_e('The original upload has been backed up.', 'tiny-compress-images'); ?></p>
+		<p><?php echo esc_html_e( 'The original upload has been backed up.', 'tiny-compress-images' ); ?></p>
 			
 		<p>
 			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
@@ -28,7 +28,7 @@ if ( $backup_enabled ) {
 			</a>
 			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
 				<strong class="tiny-dialog-title"><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></strong>
-				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images'); ?></p>
+				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images' ); ?></p>
 
 				<div class="tiny-dialog-actions">
 					<span class="spinner"></span>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -16,17 +16,18 @@ if ( $backup_enabled ) {
 	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
 	?>
 	<?php if ( $backup ) { ?>
-		<p><?php echo esc_html_e( 'The original upload has been backed up.', 'tiny-compress-images' ); ?></p>
-			
+		<p><?php esc_html_e( 'The original upload has been backed up.', 'tiny-compress-images' ); ?></p>
+
 		<p>
-			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
-				<?php esc_html_e( 'View uncompressed file' ); ?>
+			<a href="<?php echo esc_url( $backup ); ?>" target="_blank">
+				<?php esc_html_e( 'View uncompressed file', 'tiny-compress-images' ); ?>
 			</a>
 			&nbsp;
 			<a class="button button-small" href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
 				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
 			</a>
-			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
+		</p>
+		<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
 				<strong class="tiny-dialog-title"><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></strong>
 				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images' ); ?></p>
 				<p class="tiny-dialog-error" hidden></p>
@@ -40,11 +41,10 @@ if ( $backup_enabled ) {
 						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
 					</button>
 				</div>
-			</dialog>
+		</dialog>
 		<?php } else { ?>
 			<span>
 				<?php esc_html_e( 'No backup available', 'tiny-compress-images' ); ?>
 			</span>
 		<?php } ?>
-		</p>
 	<?php } ?>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -11,39 +11,39 @@ $backup_enabled = $this->settings->get_backup_enabled();
 
 ?>
 <?php
-if ($backup_enabled) {
+if ( $backup_enabled ) {
 	$backup   = $tiny_image->get_backup();
-	$modal_id = 'modal_' . absint($tiny_image->get_id()) . '_backup';
-?>
-	<?php if ($backup) { ?>
+	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
+	?>
+	<?php if ( $backup ) { ?>
 		<div class="tiny-card">
-			<p><?php esc_html_e('The original upload has been backed up.', 'tiny-compress-images'); ?><br />
-				<a href="<?php echo esc_url($backup); ?>" target="_blank">
-					<?php esc_html_e('View uncompressed file', 'tiny-compress-images'); ?>
+			<p><?php esc_html_e( 'The original upload has been backed up.', 'tiny-compress-images' ); ?><br />
+				<a href="<?php echo esc_url( $backup ); ?>" target="_blank">
+					<?php esc_html_e( 'View uncompressed file', 'tiny-compress-images' ); ?>
 				</a>
 			</p>
-			<a class="button" href="#" data-dialog-id="<?php echo esc_attr($modal_id); ?>" data-id="<?php echo absint($tiny_image->get_id()); ?>">
+			<a class="button" href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
 				<svg class="tiny-icon-backup" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M13.65 2.88c3.93 2.01 5.48 6.84 3.47 10.77s-6.83 5.48-10.77 3.47a7.94 7.94 0 0 1-3.86-4.4l1.64-1.03a6.13 6.13 0 0 0 3.08 3.76c3.01 1.54 6.69.35 8.23-2.66A6.114 6.114 0 1 0 4.56 7.21l1.88.97-4.95 3.08-.39-5.82 1.78.91C4.9 2.4 9.75.89 13.65 2.88m-4.36 7.83A1 1 0 0 1 9 10c0-.07.03-.12.04-.19h-.01L10 5l.97 4.81L14 13l-4.5-2.12.02-.02c-.08-.04-.16-.09-.23-.15"/></svg>
-				<?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?>
+				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
 			</a>
-			<dialog id="<?php echo esc_attr($modal_id); ?>" class="tiny-dialog">
-				<strong class="tiny-dialog-title"><?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?></strong>
-				<p><?php esc_html_e('This will restore the originally uncompressed image.', 'tiny-compress-images'); ?></p>
+			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
+				<strong class="tiny-dialog-title"><?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?></strong>
+				<p><?php esc_html_e( 'This will restore the originally uncompressed image.', 'tiny-compress-images' ); ?></p>
 				<p class="tiny-dialog-error" hidden></p>
 
 				<div class="tiny-dialog-actions">
 					<span class="spinner"></span>
-					<button value="cancel" commandfor="<?php echo esc_attr($modal_id); ?>" command="close" class="button">
-						<?php esc_html_e('Cancel', 'tiny-compress-images'); ?>
+					<button value="cancel" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button">
+						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
 					</button>
 					<button type="button" value="submit" class="button button-primary" autofocus>
-						<?php esc_html_e('Restore', 'tiny-compress-images'); ?>
+						<?php esc_html_e( 'Restore', 'tiny-compress-images' ); ?>
 					</button>
 				</div>
 			</dialog>
 		<?php } else { ?>
 			<span>
-				<?php esc_html_e('No backup available', 'tiny-compress-images'); ?>
+				<?php esc_html_e( 'No backup available', 'tiny-compress-images' ); ?>
 			</span>
 		<?php } ?>
 		</div>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -29,6 +29,7 @@ if ( $backup_enabled ) {
 			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
 				<strong class="tiny-dialog-title"><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></strong>
 				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images' ); ?></p>
+				<p class="tiny-dialog-error" hidden></p>
 
 				<div class="tiny-dialog-actions">
 					<span class="spinner"></span>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -37,7 +37,7 @@ if ( $backup_enabled ) {
 					<button value="cancel" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button">
 						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
 					</button>
-					<button value="submit" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="request-close" class="button button-primary" autofocus>
+					<button type="button" value="submit" class="button button-primary" autofocus>
 						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
 					</button>
 				</div>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Details on the backup of the image
  *
@@ -14,22 +15,27 @@ if ( $backup_enabled ) {
 	$backup   = $tiny_image->get_backup();
 	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
 	?>
-	<p>
-		<?php if ( $backup ) { ?>
+	<?php if ( $backup ) { ?>
+		<p><?php echo esc_html_e('The original upload has been backed up.', 'tiny-compress-images'); ?></p>
+			
+		<p>
 			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
-				<?php esc_html_e( 'View Uncompressed' ); ?>
+				<?php esc_html_e( 'View uncompressed file' ); ?>
 			</a>
+			&nbsp;
 			<a class="button button-small" href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
 				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
 			</a>
 			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
-				<p><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></p>
-				
+				<strong class="tiny-dialog-title"><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></strong>
+				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images'); ?></p>
+
 				<div class="tiny-dialog-actions">
-					<button value="close" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close">
+					<span class="spinner"></span>
+					<button value="cancel" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button">
 						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
 					</button>
-					<button value="submit" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button button-primary" autofocus>
+					<button value="submit" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="request-close" class="button button-primary" autofocus>
 						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
 					</button>
 				</div>
@@ -39,5 +45,5 @@ if ( $backup_enabled ) {
 				<?php esc_html_e( 'No backup available', 'tiny-compress-images' ); ?>
 			</span>
 		<?php } ?>
-	</p>
-<?php } ?>
+		</p>
+	<?php } ?>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -19,20 +19,20 @@ if ( $backup_enabled ) {
 			<a href="<?php echo esc_attr( $backup ); ?>" target="_blank">
 				<?php esc_html_e( 'View Uncompressed' ); ?>
 			</a>
-			<a href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
+			<a class="button button-small" href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
 				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
 			</a>
 			<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
 				<p><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></p>
 				
-				<form method="dialog" class="tiny-dialog-actions">
-					<button value="cancel" class="button">
+				<div class="tiny-dialog-actions">
+					<button value="close" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close">
 						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
 					</button>
-					<button value="confirm" class="button button-primary">
+					<button value="submit" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button button-primary" autofocus>
 						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
 					</button>
-				</form>
+				</div>
 			</dialog>
 		<?php } else { ?>
 			<span>

--- a/src/views/compress-details-backup.php
+++ b/src/views/compress-details-backup.php
@@ -11,40 +11,40 @@ $backup_enabled = $this->settings->get_backup_enabled();
 
 ?>
 <?php
-if ( $backup_enabled ) {
+if ($backup_enabled) {
 	$backup   = $tiny_image->get_backup();
-	$modal_id = 'modal_' . absint( $tiny_image->get_id() ) . '_backup';
-	?>
-	<?php if ( $backup ) { ?>
-		<p><?php esc_html_e( 'The original upload has been backed up.', 'tiny-compress-images' ); ?></p>
-
-		<p>
-			<a href="<?php echo esc_url( $backup ); ?>" target="_blank">
-				<?php esc_html_e( 'View uncompressed file', 'tiny-compress-images' ); ?>
+	$modal_id = 'modal_' . absint($tiny_image->get_id()) . '_backup';
+?>
+	<?php if ($backup) { ?>
+		<div class="tiny-card">
+			<p><?php esc_html_e('The original upload has been backed up.', 'tiny-compress-images'); ?><br />
+				<a href="<?php echo esc_url($backup); ?>" target="_blank">
+					<?php esc_html_e('View uncompressed file', 'tiny-compress-images'); ?>
+				</a>
+			</p>
+			<a class="button" href="#" data-dialog-id="<?php echo esc_attr($modal_id); ?>" data-id="<?php echo absint($tiny_image->get_id()); ?>">
+				<svg class="tiny-icon-backup" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M13.65 2.88c3.93 2.01 5.48 6.84 3.47 10.77s-6.83 5.48-10.77 3.47a7.94 7.94 0 0 1-3.86-4.4l1.64-1.03a6.13 6.13 0 0 0 3.08 3.76c3.01 1.54 6.69.35 8.23-2.66A6.114 6.114 0 1 0 4.56 7.21l1.88.97-4.95 3.08-.39-5.82 1.78.91C4.9 2.4 9.75.89 13.65 2.88m-4.36 7.83A1 1 0 0 1 9 10c0-.07.03-.12.04-.19h-.01L10 5l.97 4.81L14 13l-4.5-2.12.02-.02c-.08-.04-.16-.09-.23-.15"/></svg>
+				<?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?>
 			</a>
-			&nbsp;
-			<a class="button button-small" href="#" data-dialog-id="<?php echo esc_attr( $modal_id ); ?>" data-id="<?php echo absint( $tiny_image->get_id() ); ?>">
-				<?php esc_html_e( 'Restore Backup', 'tiny-compress-images' ); ?>
-			</a>
-		</p>
-		<dialog id="<?php echo esc_attr( $modal_id ); ?>" class="tiny-dialog">
-				<strong class="tiny-dialog-title"><?php esc_html_e( 'Are you sure you want to restore the original uncompressed image?', 'tiny-compress-images' ); ?></strong>
-				<p><?php esc_html_e( 'This action will replace all the compressed images with uncompressed images', 'tiny-compress-images' ); ?></p>
+			<dialog id="<?php echo esc_attr($modal_id); ?>" class="tiny-dialog">
+				<strong class="tiny-dialog-title"><?php esc_html_e('Restore Backup', 'tiny-compress-images'); ?></strong>
+				<p><?php esc_html_e('This will restore the originally uncompressed image.', 'tiny-compress-images'); ?></p>
 				<p class="tiny-dialog-error" hidden></p>
 
 				<div class="tiny-dialog-actions">
 					<span class="spinner"></span>
-					<button value="cancel" commandfor="<?php echo esc_attr( $modal_id ); ?>" command="close" class="button">
-						<?php esc_html_e( 'Cancel', 'tiny-compress-images' ); ?>
+					<button value="cancel" commandfor="<?php echo esc_attr($modal_id); ?>" command="close" class="button">
+						<?php esc_html_e('Cancel', 'tiny-compress-images'); ?>
 					</button>
 					<button type="button" value="submit" class="button button-primary" autofocus>
-						<?php esc_html_e( 'Yes, Restore', 'tiny-compress-images' ); ?>
+						<?php esc_html_e('Restore', 'tiny-compress-images'); ?>
 					</button>
 				</div>
-		</dialog>
+			</dialog>
 		<?php } else { ?>
 			<span>
-				<?php esc_html_e( 'No backup available', 'tiny-compress-images' ); ?>
+				<?php esc_html_e('No backup available', 'tiny-compress-images'); ?>
 			</span>
 		<?php } ?>
+		</div>
 	<?php } ?>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -111,8 +111,11 @@ ksort( $size_exists );
 				<?php echo esc_html__( 'Latest error', 'tiny-compress-images' ) . ': ' . esc_html( $error ); ?>
 			</span>
 			<br>
-		<?php } ?>
-		<a class="thickbox message" href="#TB_inline?width=700&amp;height=500&amp;inlineId=modal_<?php echo absint( $tiny_image->get_id() ); ?>">
+		<?php } 
+		/* translators: %s is the image filename */
+		$modal_title = sprintf(esc_html__( 'Compression details for %s', 'tiny-compress-images' ), esc_html( $tiny_image->get_name() ));
+		?>
+		<a class="thickbox message" name="<?php echo esc_attr($modal_title); ?>" href="#TB_inline?width=700&amp;height=500&amp;inlineId=modal_<?php echo absint( $tiny_image->get_id() ); ?>">
 			<?php esc_html_e( 'Details', 'tiny-compress-images' ); ?>
 		</a>
 	</div>
@@ -138,12 +141,6 @@ ksort( $size_exists );
 
 <div class="modal" id="modal_<?php echo absint( $tiny_image->get_id() ); ?>">
 	<div class="tiny-compression-details">
-		<h3>
-			<?php
-			/* translators: %s is the image filename */
-			printf( esc_html__( 'Compression details for %s', 'tiny-compress-images' ), esc_html( $tiny_image->get_name() ) );
-			?>
-		</h3>
 		<table>
 			<tr>
 				<th><?php esc_html_e( 'Size', 'tiny-compress-images' ); ?></th>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -10,7 +10,7 @@
 $available_sizes              = array_keys( $this->settings->get_sizes() );
 $conversion_enabled           = $this->settings->get_conversion_enabled();
 $active_sizes                 = $this->settings->get_sizes();
-$backup_enabled				  = $this->settings->get_backup_enabled();
+$backup_enabled               = $this->settings->get_backup_enabled();
 $active_tinify_sizes          = $this->settings->get_active_tinify_sizes();
 $error                        = $tiny_image->get_latest_error();
 $total                        = $tiny_image->get_count( array( 'modified', 'missing', 'has_been_compressed', 'compressed', 'has_been_converted' ) );
@@ -112,11 +112,12 @@ ksort( $size_exists );
 				<?php echo esc_html__( 'Latest error', 'tiny-compress-images' ) . ': ' . esc_html( $error ); ?>
 			</span>
 			<br>
-		<?php } 
+			<?php
+		}
 		/* translators: %s is the image filename */
-		$modal_title = sprintf(esc_html__( 'Compression details for %s', 'tiny-compress-images' ), esc_html( $tiny_image->get_name() ));
+		$modal_title = sprintf( esc_html__( 'Compression details for %s', 'tiny-compress-images' ), esc_html( $tiny_image->get_name() ) );
 		?>
-		<a class="thickbox message" name="<?php echo esc_attr($modal_title); ?>" href="#TB_inline?width=700&amp;height=500&amp;inlineId=modal_<?php echo absint( $tiny_image->get_id() ); ?>">
+		<a class="thickbox message" name="<?php echo esc_attr( $modal_title ); ?>" href="#TB_inline?width=700&amp;height=500&amp;inlineId=modal_<?php echo absint( $tiny_image->get_id() ); ?>">
 			<?php esc_html_e( 'Details', 'tiny-compress-images' ); ?>
 		</a>
 	</div>
@@ -256,6 +257,6 @@ ksort( $size_exists );
 				?>
 			</strong>
 		</p>
-		<?php include __DIR__ . '/compress-details-backup.php'; ?>
+		<?php require __DIR__ . '/compress-details-backup.php'; ?>
 	</div>
 </div>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -10,6 +10,7 @@
 $available_sizes              = array_keys( $this->settings->get_sizes() );
 $conversion_enabled           = $this->settings->get_conversion_enabled();
 $active_sizes                 = $this->settings->get_sizes();
+$backup_enabled				  = $this->settings->get_backup_enabled();
 $active_tinify_sizes          = $this->settings->get_active_tinify_sizes();
 $error                        = $tiny_image->get_latest_error();
 $total                        = $tiny_image->get_count( array( 'modified', 'missing', 'has_been_compressed', 'compressed', 'has_been_converted' ) );
@@ -255,5 +256,6 @@ ksort( $size_exists );
 				?>
 			</strong>
 		</p>
+		<?php include __DIR__ . '/compress-details-backup.php'; ?>
 	</div>
 </div>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -22,6 +22,7 @@ $size_after                   = $image_statistics['compressed_total_size'];
 
 $size_active = array_fill_keys( $active_tinify_sizes, true );
 $size_exists = array_fill_keys( $available_sizes, true );
+$has_compressed = $size_before - $size_after;
 ksort( $size_exists );
 
 ?>
@@ -243,7 +244,7 @@ ksort( $size_exists );
 		<p>
 			<strong>
 				<?php
-				if ( $size_before - $size_after ) {
+				if ( $has_compressed ) {
 					printf(
 						/* translators: %1$.0f%%: savings percentage, %2$s: total file size savings */
 						esc_html__( 'Total savings %1$.0f%% (%2$s)', 'tiny-compress-images' ),
@@ -256,7 +257,10 @@ ksort( $size_exists );
 				}
 				?>
 			</strong>
+
+			<?php if ( $has_compressed ) {
+				require __DIR__ . '/compress-details-backup.php';
+			} ?>
 		</p>
-		<?php require __DIR__ . '/compress-details-backup.php'; ?>
 	</div>
 </div>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -20,8 +20,8 @@ $available_uncompressed_sizes = $image_statistics['available_uncompressed_sizes'
 $size_before                  = $image_statistics['initial_total_size'];
 $size_after                   = $image_statistics['compressed_total_size'];
 
-$size_active = array_fill_keys( $active_tinify_sizes, true );
-$size_exists = array_fill_keys( $available_sizes, true );
+$size_active    = array_fill_keys( $active_tinify_sizes, true );
+$size_exists    = array_fill_keys( $available_sizes, true );
 $has_compressed = $size_before - $size_after;
 ksort( $size_exists );
 
@@ -258,9 +258,11 @@ ksort( $size_exists );
 				?>
 			</strong>
 
-			<?php if ( $has_compressed ) {
+			<?php
+			if ( $has_compressed ) {
 				require __DIR__ . '/compress-details-backup.php';
-			} ?>
+			}
+			?>
 		</p>
 	</div>
 </div>

--- a/src/views/compress-details.php
+++ b/src/views/compress-details.php
@@ -116,7 +116,7 @@ ksort( $size_exists );
 			<?php
 		}
 		/* translators: %s is the image filename */
-		$modal_title = sprintf( esc_html__( 'Compression details for %s', 'tiny-compress-images' ), esc_html( $tiny_image->get_name() ) );
+		$modal_title = sprintf( __( 'Compression details for %s', 'tiny-compress-images' ), $tiny_image->get_name() );
 		?>
 		<a class="thickbox message" name="<?php echo esc_attr( $modal_title ); ?>" href="#TB_inline?width=700&amp;height=500&amp;inlineId=modal_<?php echo absint( $tiny_image->get_id() ); ?>">
 			<?php esc_html_e( 'Details', 'tiny-compress-images' ); ?>

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -92,6 +92,8 @@ class WordPressStubs
 		$this->addMethod('is_multisite');
 		$this->addMethod('current_user_can');
 		$this->addMethod('wp_get_attachment_metadata');
+		$this->addMethod('wp_generate_attachment_metadata');
+		$this->addMethod('wp_update_attachment_metadata');
 		$this->addMethod('is_admin');
 		$this->addMethod('is_customize_preview');
 		$this->addMethod('is_plugin_active');
@@ -305,14 +307,11 @@ class WordPressStubs
 
 	public function createImage($file_size, $path, $name)
 	{
-		if (! $this->vfs->hasChild(self::UPLOAD_DIR . "/$path")) {
-			vfsStream::newDirectory(self::UPLOAD_DIR . "/$path")->at($this->vfs);
+		$full_dir = $this->vfs->url() . '/' . self::UPLOAD_DIR . '/' . $path;
+		if (! is_dir($full_dir)) {
+			mkdir($full_dir, 0777, true);
 		}
-		$dir = $this->vfs->getChild(self::UPLOAD_DIR . "/$path");
-
-		vfsStream::newFile($name)
-			->withContent(new LargeFileContent($file_size))
-			->at($dir);
+		file_put_contents($full_dir . '/' . $name, str_repeat("\x00", $file_size));
 	}
 
 	/**

--- a/test/helpers/wordpress.php
+++ b/test/helpers/wordpress.php
@@ -93,6 +93,7 @@ class WordPressStubs
 		$this->addMethod('current_user_can');
 		$this->addMethod('wp_get_attachment_metadata');
 		$this->addMethod('wp_generate_attachment_metadata');
+		$this->addMethod('wp_create_image_subsizes');
 		$this->addMethod('wp_update_attachment_metadata');
 		$this->addMethod('is_admin');
 		$this->addMethod('is_customize_preview');

--- a/test/integration/backup.spec.ts
+++ b/test/integration/backup.spec.ts
@@ -51,7 +51,8 @@ test.describe('backup and restore', () => {
   });
 
   test('restoring the backup replaces the compressed files with the original', async () => {
-    const original = await fs.readFile(path.join(__dirname, '../fixtures/input-example.jpg'));
+    const uncompressed = await fs.readFile(path.join(__dirname, '../fixtures/input-example.jpg'));
+    const compressed = await fs.readFile(path.join(__dirname, '../mock-tinypng-webservice/output-example.jpg'));
 
     const { attachmentID, imageURL } = await uploadMedia(page, 'input-example.jpg');
 
@@ -63,7 +64,7 @@ test.describe('backup and restore', () => {
     // different (compressed) version, otherwise the restore assertion below
     // would be meaningless.
     const compressedContent = await (await page.request.get(imageURL)).body();
-    expect(compressedContent.equals(original)).toBeFalsy();
+    expect(compressedContent.equals(compressed)).toBeTruthy();
 
     await page.getByRole('link', { name: 'Details' }).click({ force: true });
     await page.waitForSelector('#TB_overlay');
@@ -74,7 +75,9 @@ test.describe('backup and restore', () => {
 
     await expect(page.getByText('1 size to be compressed')).toBeVisible();
 
+    await page.reload();
+
     const restoredContent = await (await page.request.get(imageURL)).body();
-    expect(restoredContent.equals(original)).toBeTruthy();
+    expect(restoredContent.equals(uncompressed)).toBeTruthy();
   });
 });

--- a/test/integration/backup.spec.ts
+++ b/test/integration/backup.spec.ts
@@ -1,7 +1,7 @@
 import { Page, expect, test } from '@playwright/test';
 import fs from 'fs/promises';
 import path from 'path';
-import { enableCompressionSizes, setAPIKey, setBackupEnabled, setCompressionTiming, uploadMedia } from './utils';
+import { enableCompressionSizes, setAPIKey, setBackupEnabled, setCompressionTiming, setConversionSettings, setOriginalImage, uploadMedia } from './utils';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -21,6 +21,10 @@ test.describe('backup and restore', () => {
     await setCompressionTiming(page, 'auto');
     await enableCompressionSizes(page, ['0']);
     await setBackupEnabled(page, true);
+    // Resizing or converting makes the mock return a different image, which
+    // would break the comparisons against output-example.jpg below.
+    await setOriginalImage(page, { resize: false, preserveDate: false, preserveCopyright: false, preserveGPS: false });
+    await setConversionSettings(page, { convert: false });
   });
 
   test('enabling backup and compressing creates a backup of the original image', async () => {

--- a/test/integration/backup.spec.ts
+++ b/test/integration/backup.spec.ts
@@ -1,0 +1,80 @@
+import { Page, expect, test } from '@playwright/test';
+import fs from 'fs/promises';
+import path from 'path';
+import { enableCompressionSizes, setAPIKey, setBackupEnabled, setCompressionTiming, uploadMedia } from './utils';
+
+test.describe.configure({ mode: 'serial' });
+
+let page: Page;
+
+function viewImage(page: Page, attachmentID: string) {
+  return page.goto(`/wp-admin/post.php?post=${attachmentID}&action=edit`);
+}
+
+test.describe('backup and restore', () => {
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.beforeEach(async () => {
+    await setAPIKey(page, 'JPG123');
+    await setCompressionTiming(page, 'auto');
+    await enableCompressionSizes(page, ['0']);
+    await setBackupEnabled(page, true);
+  });
+
+  test('enabling backup and compressing creates a backup of the original image', async () => {
+    const original = await fs.readFile(path.join(__dirname, '../fixtures/input-example.jpg'));
+
+    const { attachmentID } = await uploadMedia(page, 'input-example.jpg');
+
+    await viewImage(page, attachmentID);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('1 size compressed')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Details' }).click({ force: true });
+    await page.waitForSelector('#TB_overlay');
+
+    const backupLink = page.getByRole('link', { name: 'View uncompressed file' });
+    await expect(backupLink).toBeVisible();
+
+    const backupURL = await backupLink.getAttribute('href');
+    if (!backupURL) {
+      throw new Error('backup link has no href');
+    }
+
+    const response = await page.request.get(backupURL);
+    expect(response.ok()).toBeTruthy();
+
+    const backupContent = await response.body();
+    expect(backupContent.equals(original)).toBeTruthy();
+  });
+
+  test('restoring the backup replaces the compressed files with the original', async () => {
+    const original = await fs.readFile(path.join(__dirname, '../fixtures/input-example.jpg'));
+
+    const { attachmentID, imageURL } = await uploadMedia(page, 'input-example.jpg');
+
+    await viewImage(page, attachmentID);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('1 size compressed')).toBeVisible();
+
+    // Sanity check: compression should have replaced the file on disk with a
+    // different (compressed) version, otherwise the restore assertion below
+    // would be meaningless.
+    const compressedContent = await (await page.request.get(imageURL)).body();
+    expect(compressedContent.equals(original)).toBeFalsy();
+
+    await page.getByRole('link', { name: 'Details' }).click({ force: true });
+    await page.waitForSelector('#TB_overlay');
+
+    await page.getByRole('link', { name: 'Restore Backup' }).click();
+    await expect(page.locator('dialog.tiny-dialog[open]')).toBeVisible();
+    await page.getByRole('button', { name: 'Yes, Restore' }).click();
+
+    await expect(page.getByText('1 size to be compressed')).toBeVisible();
+
+    const restoredContent = await (await page.request.get(imageURL)).body();
+    expect(restoredContent.equals(original)).toBeTruthy();
+  });
+});

--- a/test/integration/backup.spec.ts
+++ b/test/integration/backup.spec.ts
@@ -70,7 +70,7 @@ test.describe('backup and restore', () => {
 
     await page.getByRole('link', { name: 'Restore Backup' }).click();
     await expect(page.locator('dialog.tiny-dialog[open]')).toBeVisible();
-    await page.getByRole('button', { name: 'Yes, Restore' }).click();
+    await page.getByRole('button', { name: 'Restore' }).click();
 
     await expect(page.getByText('1 size to be compressed')).toBeVisible();
 

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -104,6 +104,18 @@ export async function enableCompressionSizes(page: Page, sizes: DefaultSizes[], 
   await page.locator('#submit').click();
 }
 
+export async function setBackupEnabled(page: Page, enabled: boolean) {
+  await page.goto('/wp-admin/options-general.php?page=tinify');
+
+  if (enabled) {
+    await page.locator('#tinypng_backup').check({ force: true });
+  } else {
+    await page.locator('#tinypng_backup').uncheck({ force: true });
+  }
+
+  await page.locator('#submit').click();
+}
+
 type OriginalImageSettings = {
   resize: boolean;
   width?: number;

--- a/test/unit/TinyPluginBackupTest.php
+++ b/test/unit/TinyPluginBackupTest.php
@@ -4,6 +4,7 @@ require_once dirname(__FILE__) . '/TinyTestCase.php';
 
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\assertEquals;
 
 class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 {
@@ -145,5 +146,116 @@ class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 
 		assertTrue($backup_made, 'expected backup of unscaled original to be made');
 		assertTrue(file_exists($expected_backup), 'expected backup of unscaled original to be created');
+	}
+
+	public function test_restore_backup_returns_false_when_no_backup_exists()
+	{
+		$this->wp->createImage( 37857, '2026/04', 'testfile.png' );
+
+		$wp_metadata   = array(
+			'file'  => '2026/04/testfile.png',
+			'sizes' => array(),
+		);
+		$mock_settings = $this->createMock( Tiny_Settings::class );
+		$tiny_image    = new Tiny_Image( $mock_settings, 1, $wp_metadata, null, array(), array() );
+
+		$result = $tiny_image->restore_backup();
+
+		assertFalse( $result, 'expected restore to return false when no backup exists' );
+	}
+
+	public function test_restore_backup_restores_file_from_backup()
+	{
+		// Create only the directory (via a placeholder) so the restore can write testfile.png
+		// without having to overwrite a LargeFileContent vfsStream file, which is read-only.
+		$this->wp->createImage( 1, '2026/04', '_placeholder.png' );
+		$this->wp->createImage( 100000, 'tinify_backup/2026/04', 'testfile.png' );
+
+		$this->wp->stub( 'wp_generate_attachment_metadata', function ( $id, $file ) {
+			return array(
+				'file'  => '2026/04/testfile.png',
+				'sizes' => array(),
+			);
+		} );
+
+		$wp_metadata   = array(
+			'file'  => '2026/04/testfile.png',
+			'sizes' => array(),
+		);
+		$mock_settings = $this->createMock( Tiny_Settings::class );
+		$tiny_image    = new Tiny_Image( $mock_settings, 1, $wp_metadata, null, array(), array() );
+
+		$result = $tiny_image->restore_backup();
+
+		$original_path = $this->vfs->url() . '/wp-content/uploads/2026/04/testfile.png';
+		assertTrue( $result, 'expected restore to return true' );
+		assertEquals( 100000, filesize( $original_path ), 'expected original file to be overwritten with backup content' );
+	}
+
+	public function test_restore_backup_clears_all_sizes_metadata()
+	{
+		// Create only thumbnail file (not testfile.png) so the restore writes testfile.png fresh.
+		$this->wp->createImage( 5000, '2026/04', 'testfile-150x150.png' );
+		$this->wp->createImage( 100000, 'tinify_backup/2026/04', 'testfile.png' );
+
+		$this->wp->stub( 'wp_generate_attachment_metadata', function ( $id, $file ) {
+			return array(
+				'file'  => '2026/04/testfile.png',
+				'sizes' => array(),
+			);
+		} );
+
+		$wp_metadata = array(
+			'file'  => '2026/04/testfile.png',
+			'sizes' => array(
+				'thumbnail' => array( 'file' => 'testfile-150x150.png', 'width' => 150, 'height' => 150 ),
+			),
+		);
+		$tiny_metadata = array(
+			Tiny_Image::ORIGINAL => array( 'input' => array( 'size' => 37857 ), 'output' => array( 'size' => 30000 ) ),
+			'thumbnail'          => array( 'input' => array( 'size' => 5000 ), 'output' => array( 'size' => 4000 ) ),
+		);
+		$mock_settings = $this->createMock( Tiny_Settings::class );
+		$mock_settings->method( 'get_sizes' )->willReturn( array() );
+		$mock_settings->method( 'get_active_tinify_sizes' )->willReturn( array() );
+		$tiny_image    = new Tiny_Image( $mock_settings, 1, $wp_metadata, $tiny_metadata );
+
+		$tiny_image->restore_backup();
+
+		assertEquals( array(), $tiny_image->get_image_size( Tiny_Image::ORIGINAL )->meta, 'expected original size metadata to be cleared' );
+		assertEquals( array(), $tiny_image->get_image_size( 'thumbnail' )->meta, 'expected thumbnail size metadata to be cleared' );
+	}
+
+	public function test_clean_attachment_deletes_backup_file()
+	{
+		$this->wp->createImage( 37857, '2026/04', 'testfile.png' );
+		$this->wp->createImage( 100000, 'tinify_backup/2026/04', 'testfile.png' );
+		$backup_path = $this->vfs->url() . '/wp-content/uploads/tinify_backup/2026/04/testfile.png';
+
+		$this->wp->stub( 'wp_get_attachment_metadata', function ( $i ) {
+			return array(
+				'file'  => '2026/04/testfile.png',
+				'sizes' => array(),
+			);
+		} );
+
+		$tiny_plugin   = new Tiny_Plugin();
+		$ref           = new \ReflectionClass( $tiny_plugin );
+		$settings_prop = $ref->getProperty( 'settings' );
+		$settings_prop->setAccessible( true );
+		$mock_settings = $this->createMock( Tiny_Settings::class );
+		$settings_prop->setValue( $tiny_plugin, $mock_settings );
+
+		assertTrue( file_exists( $backup_path ), 'expected backup to exist before clean_attachment' );
+		$tiny_plugin->clean_attachment( 1 );
+		assertFalse( file_exists( $backup_path ), 'expected backup to be deleted after clean_attachment' );
+	}
+
+	public function test_ajax_init_adds_restore_backup_action()
+	{
+		$tiny_plugin = new Tiny_Plugin();
+		$tiny_plugin->ajax_init();
+
+		WordPressStubs::assertHook( 'wp_ajax_tiny_restore_backup', array( $tiny_plugin, 'restore_backup_image' ) );
 	}
 }

--- a/test/unit/TinyPluginBackupTest.php
+++ b/test/unit/TinyPluginBackupTest.php
@@ -171,7 +171,7 @@ class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 		$this->wp->createImage( 1, '2026/04', '_placeholder.png' );
 		$this->wp->createImage( 100000, 'tinify_backup/2026/04', 'testfile.png' );
 
-		$this->wp->stub( 'wp_generate_attachment_metadata', function ( $id, $file ) {
+		$this->wp->stub( 'wp_create_image_subsizes', function ( $id, $file ) {
 			return array(
 				'file'  => '2026/04/testfile.png',
 				'sizes' => array(),
@@ -197,7 +197,7 @@ class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 		$this->wp->createImage( 65400, '2026/04', 'testfile-150x150.png' );
 		$this->wp->createImage( 123000, 'tinify_backup/2026/04', 'testfile.png' );
 
-		$this->wp->stub( 'wp_generate_attachment_metadata', function ( $id, $file ) {
+		$this->wp->stub( 'wp_create_image_subsizes', function ( $id, $file ) {
 			return array(
 				'file'  => '2026/04/testfile.png',
 				'sizes' => array(

--- a/test/unit/TinyPluginBackupTest.php
+++ b/test/unit/TinyPluginBackupTest.php
@@ -194,14 +194,17 @@ class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 
 	public function test_restore_backup_clears_all_sizes_metadata()
 	{
-		// Create only thumbnail file (not testfile.png) so the restore writes testfile.png fresh.
-		$this->wp->createImage( 5000, '2026/04', 'testfile-150x150.png' );
-		$this->wp->createImage( 100000, 'tinify_backup/2026/04', 'testfile.png' );
+		$this->wp->createImage( 65400, '2026/04', 'testfile-150x150.png' );
+		$this->wp->createImage( 123000, 'tinify_backup/2026/04', 'testfile.png' );
 
 		$this->wp->stub( 'wp_generate_attachment_metadata', function ( $id, $file ) {
 			return array(
 				'file'  => '2026/04/testfile.png',
-				'sizes' => array(),
+				'sizes' => array(
+					'thumbnail' => array(
+						'file' => '2026/04/testfile-150x150.png',
+					)
+				),
 			);
 		} );
 
@@ -211,19 +214,31 @@ class Tiny_Plugin_Backup_Test extends Tiny_TestCase
 				'thumbnail' => array( 'file' => 'testfile-150x150.png', 'width' => 150, 'height' => 150 ),
 			),
 		);
+		$mock_settings = $this->createMock( Tiny_Settings::class );
+		$mock_settings->method( 'get_sizes' )->willReturn( array(
+			Tiny_Image::ORIGINAL,
+			'thumbnail',
+		) );
+		$mock_settings->method( 'get_active_tinify_sizes' )->willReturn( array(
+			Tiny_Image::ORIGINAL,
+			'thumbnail',
+		) );
 		$tiny_metadata = array(
 			Tiny_Image::ORIGINAL => array( 'input' => array( 'size' => 37857 ), 'output' => array( 'size' => 30000 ) ),
 			'thumbnail'          => array( 'input' => array( 'size' => 5000 ), 'output' => array( 'size' => 4000 ) ),
 		);
-		$mock_settings = $this->createMock( Tiny_Settings::class );
-		$mock_settings->method( 'get_sizes' )->willReturn( array() );
-		$mock_settings->method( 'get_active_tinify_sizes' )->willReturn( array() );
 		$tiny_image    = new Tiny_Image( $mock_settings, 1, $wp_metadata, $tiny_metadata );
+
+		assertEquals($tiny_image->get_image_size( 'thumbnail' )->filesize(), 65400, 'thumbnail before restoring'); 
+		
+		// wp_generate_attachment_metadata will regenerate new thumbnails, mock this by creating
+		// a new thumbnail on vfs
+		// https://developer.wordpress.org/reference/functions/wp_generate_attachment_metadata/
+		$this->wp->createImage( 123654, '2026/04', 'testfile-150x150.png' );
 
 		$tiny_image->restore_backup();
 
-		assertEquals( array(), $tiny_image->get_image_size( Tiny_Image::ORIGINAL )->meta, 'expected original size metadata to be cleared' );
-		assertEquals( array(), $tiny_image->get_image_size( 'thumbnail' )->meta, 'expected thumbnail size metadata to be cleared' );
+		assertEquals($tiny_image->get_image_size( 'thumbnail' )->filesize(), 123654, 'thumbnail before restoring'); 
 	}
 
 	public function test_clean_attachment_deletes_backup_file()

--- a/test/wp-includes-for-tests/file.php
+++ b/test/wp-includes-for-tests/file.php
@@ -15,7 +15,14 @@ class WP_Filesystem_Base {
 		if ( ! $overwrite && file_exists( $dest ) ) {
 			return false;
 		}
-		return copy( $src, $dest );
+		// Use file_get_contents + file_put_contents instead of copy() so that
+		// vfsStream files backed by LargeFileContent (read-only virtual content)
+		// can be overwritten in tests.
+		$content = file_get_contents( $src );
+		if ( false === $content ) {
+			return false;
+		}
+		return file_put_contents( $dest, $content ) !== false;
 	}
 
 	public function get_contents( $path ) {


### PR DESCRIPTION
https://github.com/tinify/wordpress-plugin/pull/98 added backups of the original image. This will add the restore functionality.

**Screenshots**
<img width="844" height="452" alt="image" src="https://github.com/user-attachments/assets/4e2801a5-3ba8-4939-8d3c-4da640b0bdee" />

When a backup is created, we will check in the media library if the image has a backup available. If so, the customer can restore the image in the details modal. This will make a API call to the back-end (ajax action). This will attempt to restore the uncompressed uploaded image.

- Automatic compression will not be triggered.

Additionally in this pull request:

- moved backup functionality to tiny image so that we functionality is contained to the image domain
- improved error handling with the file system, for when direct file manipulation is not possible due to write constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic backups of original images during compression.
  - Added options to view, restore, and delete image backups.
  - Added confirmation dialogs, progress feedback, and refreshed media details after restoration.

- **Bug Fixes**
  - Backups are removed when attachments are deleted.
  - Improved restored image metadata, thumbnails, and compression information.
  - Improved error handling when filesystem access is unavailable.

- **Documentation**
  - Updated compression hook documentation with image metadata details.

- **Style**
  - Updated compression details spacing and dialog styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->