### PR TITLE
clear memoized data when updating meta data

### DIFF
--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -53,7 +53,21 @@ class Tiny_Image_Size {
 		if ( isset( $this->meta['start'] ) ) {
 			$this->meta        = $response;
 			$this->meta['end'] = time();
+			$this->reset_memoized_filesystem_values();
 		}
+	}
+
+	/**
+	 * Clears the memoized exists/file_size/mime_type values.
+	 *
+	 * Must be called whenever the file on disk changed after those were
+	 * memoized, e.g. after compression overwrites it, so the next read
+	 * reflects the new file instead of the stale cached one.
+	 */
+	private function reset_memoized_filesystem_values() {
+		$this->exists    = null;
+		$this->file_size = null;
+		$this->mime_type = null;
 	}
 
 	public function add_tiny_meta_error( $exception ) {

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -71,7 +71,7 @@ class Tiny_Image_Size {
 		if ( isset( $this->meta['start'] ) ) {
 			$this->meta        = $response;
 			$this->meta['end'] = time();
-			$this->reset_memoized_filesystem();
+			$this->clear_memoized_filesystem();
 		}
 	}
 
@@ -84,7 +84,7 @@ class Tiny_Image_Size {
 	 *
 	 * @return void
 	 */
-	private function reset_memoized_filesystem() {
+	private function clear_memoized_filesystem() {
 		clearstatcache( true, $this->filename );
 		$this->exists    = null;
 		$this->file_size = null;

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -63,6 +63,8 @@ class Tiny_Image_Size {
 	 * Must be called whenever the file on disk changed after those were
 	 * memoized, e.g. after compression overwrites it, so the next read
 	 * reflects the new file instead of the stale cached one.
+	 * 
+	 * @return void
 	 */
 	private function reset_memoized_filesystem_values() {
 		$this->exists    = null;

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -22,9 +22,25 @@ class Tiny_Image_Size {
 	public $filename;
 	public $meta = array();
 
-	/* Used more than once and not trivial, so we are memoizing these */
+	/**
+	 * Whether the file exists on disk.
+	 *
+	 * @var bool|null $exists
+	 */
 	private $exists;
+
+	/**
+	 * File size in bytes.
+	 *
+	 * @var int|null $file_size
+	 */
 	private $file_size;
+
+	/**
+	 * MIME type of the file.
+	 *
+	 * @var string|null $mime_type
+	 */
 	private $mime_type;
 	private $duplicate         = false;
 	private $duplicate_of_size = '';
@@ -53,7 +69,7 @@ class Tiny_Image_Size {
 		if ( isset( $this->meta['start'] ) ) {
 			$this->meta        = $response;
 			$this->meta['end'] = time();
-			$this->reset_memoized_filesystem_values();
+			$this->reset_memoized_filesystem();
 		}
 	}
 
@@ -66,7 +82,7 @@ class Tiny_Image_Size {
 	 * 
 	 * @return void
 	 */
-	private function reset_memoized_filesystem_values() {
+	private function reset_memoized_filesystem() {
 		$this->exists    = null;
 		$this->file_size = null;
 		$this->mime_type = null;

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -79,7 +79,7 @@ class Tiny_Image_Size {
 	 * Must be called whenever the file on disk changed after those were
 	 * memoized, e.g. after compression overwrites it, so the next read
 	 * reflects the new file instead of the stale cached one.
-	 * 
+	 *
 	 * @return void
 	 */
 	private function reset_memoized_filesystem() {

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -85,6 +85,7 @@ class Tiny_Image_Size {
 	 * @return void
 	 */
 	private function reset_memoized_filesystem() {
+		clearstatcache( true, $this->filename );
 		$this->exists    = null;
 		$this->file_size = null;
 		$this->mime_type = null;

--- a/src/class-tiny-image-size.php
+++ b/src/class-tiny-image-size.php
@@ -42,7 +42,9 @@ class Tiny_Image_Size {
 	 * @var string|null $mime_type
 	 */
 	private $mime_type;
-	private $duplicate         = false;
+
+	private $duplicate = false;
+
 	private $duplicate_of_size = '';
 
 	public function __construct( $filename = null ) {

--- a/test/unit/TinyImageSizeTest.php
+++ b/test/unit/TinyImageSizeTest.php
@@ -63,12 +63,12 @@ class Tiny_Image_Size_Test extends Tiny_TestCase {
 	 * the memoized file_size so the next filesize() call reflects the new file
 	 * rather than returning the stale pre-compression value.
 	 */
-	public function test_add_tiny_meta_resets_memoized_filesize_after_compression() {
+	public function test_add_tiny_meta_clears_memoized_data_after_compression() {
+		$this->original->add_tiny_meta_start();
 		$this->assertEquals( 137856, $this->original->filesize(), 'expected filesize to be original' );
 
 		file_put_contents( $this->original->filename, str_repeat( 'a', 90000 ) );
 
-		$this->original->add_tiny_meta_start();
 		$this->original->add_tiny_meta( array(
 			'input'  => array( 'size' => 137856 ),
 			'output' => array( 'size' => 90000 ),

--- a/test/unit/TinyImageSizeTest.php
+++ b/test/unit/TinyImageSizeTest.php
@@ -58,6 +58,25 @@ class Tiny_Image_Size_Test extends Tiny_TestCase {
 		$this->assertEqualWithinDelta( time(), $this->large->meta['end'], 2 );
 	}
 
+	/**
+	 * After compression overwrites the file on disk, add_tiny_meta() must clear
+	 * the memoized file_size so the next filesize() call reflects the new file
+	 * rather than returning the stale pre-compression value.
+	 */
+	public function test_add_tiny_meta_resets_memoized_filesize_after_compression() {
+		$this->assertEquals( 137856, $this->original->filesize(), 'expected filesize to be original' );
+
+		file_put_contents( $this->original->filename, str_repeat( 'a', 90000 ) );
+
+		$this->original->add_tiny_meta_start();
+		$this->original->add_tiny_meta( array(
+			'input'  => array( 'size' => 137856 ),
+			'output' => array( 'size' => 90000 ),
+		) );
+
+		$this->assertEquals( 90000, $this->original->filesize(), 'should return refreshed filesize' );
+	}
+
 	public function test_add_response_should_response() {
 		$this->large->add_tiny_meta_start();
 		$this->large->add_tiny_meta( array(


### PR DESCRIPTION
fs data is memoized (private variables) and cached (statcache).
`add_tiny_meta` is called when compression starts and ends. This usually updates the file on disk, which should update the filesize.

This bug was visible in the media library as it showed, for example, `3 sizes compressed, 3 sizes to compress` which would not be possible.