### PR TITLE
Support for WordPress 7.1 & PHP8.5

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,11 +17,10 @@ jobs:
         include:
           - { wp: 46, php: 56 }
           - { wp: 46, php: 70 }
+          - { wp: 57, php: 73 }
           - { wp: 60, php: 74 }
-          - { wp: 63, php: 80 }
-          - { wp: 67, php: 82 }
-          - { wp: 69, php: 83 }
           - { wp: 70, php: 84 }
+          - { wp: 71, php: 85 }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/config/wp-version.conf
+++ b/config/wp-version.conf
@@ -3,7 +3,5 @@
 46_70=wordpress:4.6-php7.0-apache
 57_73=wordpress:5.7-php7.3-apache
 60_74=wordpress:6.0-php7.4-apache
-63_80=wordpress:6.3-php8.0-apache
-67_82=wordpress:6.7-php8.2-apache
-69_83=wordpress:6.9-php8.3-apache
-70_84=wordpress:beta-7.0-RC2-php8.4-apache
+70_84=wordpress:7.0-php8.4-apache
+71_85=wordpress:beta-7.1-php8.5-apache

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: TinyPNG
 Donate link: https://tinypng.com/
 Tags: compress images, compression, image size, page speed, performance
 Requires at least: 4.0
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 3.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/class-tiny-compress-client.php
+++ b/src/class-tiny-compress-client.php
@@ -197,7 +197,13 @@ class Tiny_Compress_Client extends Tiny_Compress {
 		The client does not let us override cURL properties yet, so we have
 			to use a reflection property. */
 		$property = new ReflectionProperty( $client, 'options' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			/**
+			 * No effect since PHP 8.1 and deprecated since PHP 8.5
+			 * https://www.php.net/manual/en/reflectionproperty.setaccessible.php
+			 */
+			$property->setAccessible( true );
+		}
 		$options = $property->getValue( $client );
 
 		// Set API request timeout to prevent indefinite hanging

--- a/test/fixtures/Client.php
+++ b/test/fixtures/Client.php
@@ -120,6 +120,11 @@ class Client {
 	protected static function closeRequest( $request ) {
 		if ( PHP_VERSION_ID < 80000 ) {
 			curl_close( $request );
+		} elseif (
+			is_object($request) &&
+			method_exists($request, 'close')
+		) { 
+			$request->close(); 
 		}
 	}
 

--- a/test/fixtures/Client.php
+++ b/test/fixtures/Client.php
@@ -53,7 +53,7 @@ class Client {
 		if ( is_string( $response ) ) {
 			$status = curl_getinfo( $request, CURLINFO_HTTP_CODE );
 			$headerSize = curl_getinfo( $request, CURLINFO_HEADER_SIZE );
-			curl_close( $request );
+			self::closeRequest( $request );
 
 			$headers = self::parseHeaders( substr( $response, 0, $headerSize ) );
 			$body = substr( $response, $headerSize );
@@ -107,9 +107,20 @@ class Client {
 			);
 		} else {
 			$message = sprintf( '%s (#%d)', curl_error( $request ), curl_errno( $request ) );
-			curl_close( $request );
+			self::closeRequest( $request );
 			throw new ConnectionException( 'Error while connecting: ' . $message );
 		}// End if().
+	}
+
+	/**
+	 * curl_close() is deprecated in >8.5, does nothing in >8.0 
+	 * 
+	 * @param \Tinify\CurlMock $request
+	 */
+	protected static function closeRequest( $request ) {
+		if ( PHP_VERSION_ID < 80000 ) {
+			curl_close( $request );
+		}
 	}
 
 	protected static function parseHeaders( $headers ) {

--- a/test/unit/TinyImageSizeTest.php
+++ b/test/unit/TinyImageSizeTest.php
@@ -194,8 +194,12 @@ class Tiny_Image_Size_Test extends Tiny_TestCase {
 	}
 
 	public function test_will_read_mimetype_from_file() {
-		// because files in the virtual file system are not really files but empty strings, it is a text/plain.
-		$this->assertEquals( $this->original->mimetype(), 'text/plain');
+		// vfs files are empty buffers
+		// empty buffers on php < 8 returns 'text/plain', > 8 is 'application/octet-stream'
+		$this->assertContains(
+			$this->original->mimetype(),
+			array( 'text/plain', 'application/octet-stream' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Two deprecations worth mentioning in WP7.1 & PHP8.5:
- setAccessible is made a private property mutable. This is mutable by default in >PHP8.
- curl_close is also no longer required. Was only done in test fixtures.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility testing for WordPress 7.1 with PHP 8.5.
  * Updated compatibility information to indicate support through WordPress 7.1.

* **Bug Fixes**
  * Improved compatibility with PHP 8.1 and later by avoiding deprecated reflection behavior.
  * Improved request cleanup across supported PHP versions, helping prevent resource-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->