### PR TITLE
fix - bulk optimization compression results past 9 are not shown

### DIFF
--- a/src/js/bulk-optimization.js
+++ b/src/js/bulk-optimization.js
@@ -202,8 +202,9 @@
 
   function drawSomeRows(items, rowsToDraw) {
     const list = jQuery('#optimization-items tbody');
-    let drawNow = window.totalRowsDrawn;
-    for(let i = drawNow;i < Math.min(rowsToDraw + window.totalRowsDrawn, items.length); i++) {
+    const start = window.totalRowsDrawn;
+    const end = Math.min(start + rowsToDraw, items.length);
+    for (let i = start; i < end; i++) {
       const tableRow = `<tr class="media-item">
         <td class="thumbnail" />
         <td class="column-primary name">${items[i].post_title}</th>
@@ -213,9 +214,8 @@
         <td class="column-author status" data-testid="bulk-item-status-${i}" data-colname="${tinyCompress.L10nStatus}" data-status="waiting">${tinyCompress.L10nWaiting}</td>
       </tr>`;
       list.append(tableRow);
-      drawNow = i + 1;
     }
-    window.totalRowsDrawn = drawNow;
+    window.totalRowsDrawn = end;
   }
 
   function cancelOptimization() {

--- a/src/js/bulk-optimization.js
+++ b/src/js/bulk-optimization.js
@@ -213,7 +213,7 @@
         <td class="column-author status" data-testid="bulk-item-status-${i}" data-colname="${tinyCompress.L10nStatus}" data-status="waiting">${tinyCompress.L10nWaiting}</td>
       </tr>`;
       list.append(tableRow);
-      drawNow = i;
+      drawNow = i + 1;
     }
     window.totalRowsDrawn = drawNow;
   }

--- a/test/unit/TinyImageSizeTest.php
+++ b/test/unit/TinyImageSizeTest.php
@@ -194,8 +194,12 @@ class Tiny_Image_Size_Test extends Tiny_TestCase {
 	}
 
 	public function test_will_read_mimetype_from_file() {
-		// because files in the virtual file system are not really files but empty strings, it is a text/plain.
-		$this->assertEquals( $this->original->mimetype(), 'text/plain');
+		// vfs files are empty buffers
+		// empty buffers on php < 8 returns 'text/plain', > 8 is 'application/octet-stream'
+		$this->assertContains(
+			$this->original->mimetype(),
+			array( 'text/plain', 'application/octet-stream' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
`drawSomeRows()` records the last index it drew instead of how many rows it has drawn. Therefor compression more than 10 images would never show the results of images past 9.

Tricky to add a regression test as it requires more than 10 images to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected row-count tracking so the total number of rendered rows is reported accurately.
  * Improved incremental rendering to prevent previously rendered rows from being redrawn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->