### PR TITLE
3.8.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -176,7 +176,7 @@ A: When the conversion feature is enabled (to convert images to AVIF or WebP), e
 == Changelog ==
 = 3.8.0 =
 * feat: option to create a backup of the original uploaded image
-* fix: will not used setAccessible on newer PHP versions 
+* fix: will not use setAccessible on newer PHP versions
 * fix: correctly resets index when bulk optimizing
 * fix: clears memoized metadata when it is updated
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://tinypng.com/
 Tags: compress images, compression, image size, page speed, performance
 Requires at least: 4.0
 Tested up to: 7.1
-Stable tag: 3.7.0
+Stable tag: 3.8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -174,6 +174,12 @@ A: You can upgrade to a paid account by adding your *Payment details* on your [a
 A: When the conversion feature is enabled (to convert images to AVIF or WebP), each image will use double the number of credits: one for compression and one for format conversion.
 
 == Changelog ==
+= 3.8.0 =
+* feat: option to create a backup of the original uploaded image
+* fix: will not used setAccessible on newer PHP versions 
+* fix: correctly resets index when bulk optimizing
+* fix: clears memoized metadata when it is updated
+
 = 3.7.0 =
 * chore: migrated meta key from `tiny_compress_images` to `_tiny_compress_images`
 * feat: when original is set to be compressed, it will also compress images filtered by big_image_size_threshold.

--- a/src/class-tiny-plugin.php
+++ b/src/class-tiny-plugin.php
@@ -18,7 +18,7 @@
 * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 class Tiny_Plugin extends Tiny_WP_Base {
-	const VERSION         = '3.7.0';
+	const VERSION         = '3.8.0';
 	const MEDIA_COLUMN    = self::NAME;
 	const DATETIME_FORMAT = 'Y-m-d G:i:s';
 

--- a/tiny-compress-images.php
+++ b/tiny-compress-images.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: TinyPNG - JPEG, PNG & WebP image compression
  * Description: Speed up your website. Optimize your JPEG, PNG, and WebP images automatically with TinyPNG.
- * Version: 3.7.0
+ * Version: 3.8.0
  * Author: TinyPNG
  * Author URI: https://tinypng.com
  * Text Domain: tiny-compress-images


### PR DESCRIPTION
* feat: option to create a backup of the original uploaded image
* fix: will not used setAccessible on newer PHP versions 
* fix: correctly resets index when bulk optimizing
* fix: clears memoized metadata when it is updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for backing up original images.
  * Improved compatibility with newer PHP versions.
  * Added bulk optimization index reset functionality.
  * Added memoized metadata clearing.

* **Chores**
  * Updated the plugin version to 3.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->